### PR TITLE
fix: batch image placement to prevent intermittent display

### DIFF
--- a/lua/md-render/display_utils.lua
+++ b/lua/md-render/display_utils.lua
@@ -356,20 +356,30 @@ function M.setup_images(win, content, on_download)
   local function redraw_images()
     if not vim.api.nvim_win_is_valid(state.win) then return end
     vim.cmd("redraw!")
-    for _, placement in ipairs(state.placements) do
-      local anim = state.anims[placement.path]
-      if anim then
-        local id = anim.frame_ids[anim.current]
-        if id then
-          image.put_image(id, state.win, placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
-        end
-      else
-        local id = state.image_ids[placement.path]
-        if id then
-          image.put_image(id, state.win, placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
+    -- Defer image placement to the next event loop tick so the TUI's
+    -- output buffer from redraw! is fully flushed to the terminal before
+    -- we write Kitty graphics commands directly to the TTY.
+    vim.schedule(function()
+      if not vim.api.nvim_win_is_valid(state.win) then return end
+      -- Batch all image placement commands into a single term_write to
+      -- avoid per-image TTY open/close overhead and ensure atomicity.
+      image.begin_batch()
+      for _, placement in ipairs(state.placements) do
+        local anim = state.anims[placement.path]
+        if anim then
+          local id = anim.frame_ids[anim.current]
+          if id then
+            image.put_image(id, state.win, placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
+          end
+        else
+          local id = state.image_ids[placement.path]
+          if id then
+            image.put_image(id, state.win, placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
+          end
         end
       end
-    end
+      image.flush_batch()
+    end)
   end
 
   local function schedule_redraw()

--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -13,6 +13,12 @@ local uv = vim.uv or vim.loop
 local ffi = require("ffi")
 
 -- ============================================================================
+-- Batched terminal writes
+-- ============================================================================
+
+local _batch_buffer = nil
+
+-- ============================================================================
 -- TTY setup (cached at module level)
 -- ============================================================================
 
@@ -35,6 +41,10 @@ end
 ---@param data string
 local function term_write(data)
   if data == "" then return end
+  if _batch_buffer then
+    table.insert(_batch_buffer, data)
+    return
+  end
   local tty = get_tty_path()
   if tty then
     local f = io.open(tty, "w")
@@ -53,7 +63,23 @@ end
 
 local function move_cursor(x, y)
   term_write("\x1b[" .. y .. ";" .. x .. "H")
-  uv.sleep(1)
+  if not _batch_buffer then
+    uv.sleep(1)
+  end
+end
+
+--- Start batching terminal writes. Subsequent term_write calls accumulate
+--- in memory instead of writing to the terminal immediately.
+function M.begin_batch()
+  _batch_buffer = {}
+end
+
+--- Flush all accumulated terminal writes as a single write operation.
+function M.flush_batch()
+  if not _batch_buffer then return end
+  local data = table.concat(_batch_buffer)
+  _batch_buffer = nil
+  term_write(data)
 end
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

- `redraw_images()` で `redraw!` 直後に Kitty 画像配置コマンドを送信していたが、TUI の出力バッファがフラッシュされる前に画像コマンドが到着し、TUI の出力で上書きされることがあった
- `vim.schedule()` で画像配置を次のイベントループに遅延し、TUI 出力のフラッシュを待つように修正
- `begin_batch()` / `flush_batch()` を追加し、全画像の配置コマンドを1回の TTY 書き込みにまとめることで、画像数 × 4 回の TTY open/close を1回に削減

## Test plan

- [x] 既存テスト通過 (154 passed, 0 failed)
- [ ] 画像を多数含む Markdown ファイル（Qiita 記事等）でプレビューを繰り返し開閉し、画像が安定して表示されることを確認
- [ ] スクロール時に画像が正しく再配置されることを確認
- [ ] アニメーション GIF が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)