### PR TITLE
fix: multi-terminal image display support

### DIFF
--- a/lua/md-render/display_utils.lua
+++ b/lua/md-render/display_utils.lua
@@ -41,6 +41,14 @@ function M.supports_osc8()
     return true
   end
 
+  -- Fallback: detect via terminal-specific env vars
+  if vim.env.KITTY_WINDOW_ID
+    or vim.env.GHOSTTY_RESOURCES_DIR
+    or vim.env.WEZTERM_EXECUTABLE then
+    _osc8_supported = true
+    return true
+  end
+
   _osc8_supported = false
   return false
 end

--- a/lua/md-render/display_utils.lua
+++ b/lua/md-render/display_utils.lua
@@ -417,6 +417,12 @@ function M.setup_images(win, content, on_download)
     -- avoid per-image TTY open/close overhead and ensure atomicity.
     image.begin_batch()
     local ok, err = pcall(function()
+      -- Clear existing placements before re-placing. Kitty and Ghostty
+      -- keep placements across redraws (unlike WezTerm which clears on redraw!).
+      -- Clearing is harmless on WezTerm (already gone after redraw!).
+      for _, id in pairs(state.image_ids) do
+        image.clear_placements(id)
+      end
       for _, placement in ipairs(state.placements) do
         local anim = state.anims[placement.path]
         if anim then
@@ -489,9 +495,13 @@ function M.setup_images(win, content, on_download)
               timer:stop()
               return
             end
+            local prev_id = anim.frame_ids[anim.current]
             anim.current = anim.current % #anim.frame_ids + 1
+            image.begin_batch()
+            image.clear_placements(prev_id)
             image.put_image(anim.frame_ids[anim.current], state.win,
               placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
+            image.flush_batch()
           end))
         end)
       else
@@ -619,6 +629,8 @@ function M.cleanup_images(state)
   end
 
   image.delete_images(ids)
+  -- Robust fallback: some terminals (Ghostty) may not support per-ID deletion
+  image.delete_all()
 
   -- Stop redraw timer
   if state.redraw_timer then

--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -1011,6 +1011,19 @@ function M.put_image(image_id, win, row, col, display_cols, display_rows, anim_p
   term_write("\x1b[u")
 end
 
+--- Delete all placements for an image but keep the transmitted data.
+---@param image_id integer
+function M.clear_placements(image_id)
+  if not M.supports_kitty() then return end
+  term_write(string.format("\x1b_Ga=d,d=a,i=%d,q=2\x1b\\", image_id))
+end
+
+--- Delete all images and placements from terminal memory.
+function M.delete_all()
+  if not M.supports_kitty() then return end
+  term_write("\x1b_Ga=d,d=A,q=2\x1b\\")
+end
+
 --- Delete a stored image from terminal memory
 ---@param image_id integer
 function M.delete_image(image_id)

--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -760,7 +760,7 @@ function M.transmit_animated(path)
     local id = _image_id
     local b64_path = vim.base64.encode(frame_path)
     term_write(string.format(
-      "\x1b_Ga=t,f=100,t=t,i=%d,q=2;%s\x1b\\",
+      "\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\",
       id, b64_path
     ))
     table.insert(frame_ids, id)
@@ -836,7 +836,7 @@ function M.transmit_animated_async(path, callback)
                 local id = _image_id
                 local b64_path = vim.base64.encode(first_frame)
                 term_write(string.format(
-                  "\x1b_Ga=t,f=100,t=t,i=%d,q=2;%s\x1b\\",
+                  "\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\",
                   id, b64_path
                 ))
                 callback({ id }, tmp_dir)
@@ -897,7 +897,7 @@ function M.transmit_animated_async(path, callback)
               local id = _image_id
               local b64_path = vim.base64.encode(frame_path)
               term_write(string.format(
-                "\x1b_Ga=t,f=100,t=t,i=%d,q=2;%s\x1b\\",
+                "\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\",
                 id, b64_path
               ))
               table.insert(frame_ids, id)

--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -950,6 +950,8 @@ function M.put_image(image_id, win, row, col, display_cols, display_rows, anim_p
     if img_h then
       local crop_y = math.floor(img_h * hidden_rows / display_rows)
       crop_params = crop_params .. ",y=" .. crop_y
+      -- Explicit h= required: some terminals (Ghostty) need both y= and h=
+      crop_params = crop_params .. ",h=" .. (img_h - crop_y)
     end
     display_rows = display_rows - hidden_rows
     visual_row = 0
@@ -968,7 +970,13 @@ function M.put_image(image_id, win, row, col, display_cols, display_rows, anim_p
       remaining_h = img_h - tonumber(existing_y)
     end
     local crop_h = math.floor(remaining_h * visible_rows / display_rows)
-    crop_params = crop_params .. ",h=" .. crop_h
+    -- Update h= if already set by top crop, otherwise add it
+    local existing_h = crop_params:match(",h=%d+")
+    if existing_h then
+      crop_params = crop_params:gsub(",h=%d+", ",h=" .. crop_h)
+    else
+      crop_params = crop_params .. ",h=" .. crop_h
+    end
     display_rows = visible_rows
   end
 

--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -424,6 +424,20 @@ function M.supports_kitty()
       return true
     end
   end
+  -- Fallback: detect via terminal-specific env vars that Neovim may preserve
+  -- even when TERM_PROGRAM is cleared
+  if vim.env.KITTY_WINDOW_ID then
+    _kitty_supported = true
+    return true
+  end
+  if vim.env.GHOSTTY_RESOURCES_DIR then
+    _kitty_supported = true
+    return true
+  end
+  if vim.env.WEZTERM_EXECUTABLE then
+    _kitty_supported = true
+    return true
+  end
   _kitty_supported = false
   return false
 end

--- a/lua/md-render/preview.lua
+++ b/lua/md-render/preview.lua
@@ -199,6 +199,8 @@ MdPreview.show = function(opts)
   end
 
   local target = find_rendered_line(source_cursor_line, content)
+  local buf_lines = vim.api.nvim_buf_line_count(vim.api.nvim_win_get_buf(win))
+  target = math.max(1, math.min(target, buf_lines))
   -- Place the target line near the center of the float window
   local win_height = vim.api.nvim_win_get_height(win)
   local top = math.max(0, target - 1 - math.floor(win_height / 2))


### PR DESCRIPTION
## Summary
- **Terminal detection**: Fall back to `KITTY_WINDOW_ID`, `GHOSTTY_RESOURCES_DIR`, `WEZTERM_EXECUTABLE` when `TERM_PROGRAM` is unset (fixes Kitty/Ghostty where Neovim doesn't inherit it)
- **Ghostty top crop**: Explicitly specify `h=` alongside `y=` in source rectangle cropping to prevent image squishing
- **Animated GIF transmission**: Use `t=f` (regular file) instead of `t=t` (temp file) for broader terminal compatibility
- **Scroll placement cleanup**: Clear stale image placements before re-placing on scroll (fixes Kitty/Ghostty accumulation)
- **Animation timer**: Batch TTY writes (4→1 per frame) and clear previous frame placement
- **Cleanup fallback**: Add `delete_all` in `cleanup_images` for terminals lacking per-ID deletion
- **Preview cursor**: Clamp cursor position to buffer bounds to prevent out-of-range error

## Known limitations
- Ghostty has incomplete Kitty Graphics Protocol support (no per-ID placement deletion, no placement replacement). Basic image display and scrolling work, but animation frames may accumulate. These are upstream Ghostty issues (#6710, #6711).

## Remaining work
- [ ] Ghostty: `clear_placements` (`a=d,d=a`) が効かないため、スクロール時に画像が残る可能性がある。`delete_all` + 全画像再送信へのフォールバックが必要だが、Ghostty 検出 + 再送信用のパス管理が追加で必要
- [ ] Ghostty: アニメーション GIF は Ghostty のプロトコル制限（プレースメント置換不可）により正常動作しない。静的表示へのフォールバックを検討
- [ ] 3ターミナル (WezTerm, Kitty, Ghostty) での統合テスト

## Test plan
- [ ] WezTerm: static images display and scroll correctly
- [ ] WezTerm: animated GIFs play without flickering
- [ ] WezTerm: images disappear when preview window closes
- [ ] Kitty: static images display and scroll correctly
- [ ] Kitty: animated GIFs play without flickering
- [ ] Kitty: images disappear when preview window closes
- [ ] Ghostty: static images display and scroll correctly
- [ ] Ghostty: images disappear when preview window closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)