### PR TITLE
fix: use non-NUL separator in mermaid_cache_path

### DIFF
--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -407,7 +407,7 @@ end
 ---@return string
 local function mermaid_cache_path(source)
   local theme, bg_hex = mermaid_theme_args()
-  local hash = vim.fn.sha256(source .. "\0" .. theme .. "\0" .. bg_hex):sub(1, 16)
+  local hash = vim.fn.sha256(source .. "|" .. theme .. "|" .. bg_hex):sub(1, 16)
   return get_mermaid_cache_dir() .. "/" .. hash .. ".png"
 end
 


### PR DESCRIPTION
## Summary
- Swaps the NUL byte separator (`"\0"`) for `"|"` in `mermaid_cache_path`
- The NUL byte causes the Lua→vimscript bridge to convert the concatenated string to a Blob on Neovim ≤ 0.11, which `vim.fn.sha256()` rejects with E976
- Fixed upstream in v0.12 (vim-patch 9.1.1774), so this only affects ≤ 0.11

Closes #7