### PR TITLE
feat(autolink): render <URL> inline and embed user-attachments media

### DIFF
--- a/lua/md-render/content_builder.lua
+++ b/lua/md-render/content_builder.lua
@@ -2291,6 +2291,17 @@ function ContentBuilder:render_document(lines, opts)
               end
             end
           end
+          -- CommonMark autolink to GitHub user-attachments CDN: <https://github.com/user-attachments/assets/...>
+          -- These URLs have no extension; GitHub's web UI inlines them as <video>/<img>
+          -- based on Content-Type. Restrict to this CDN so non-media URLs do not get
+          -- stuck on a "Loading..." placeholder.
+          if not img_path then
+            local autolink_url = line:match "^%s*<(https?://github%.com/user%-attachments/[%w%-/%.]+)>%s*$"
+            if autolink_url then
+              img_path = autolink_url
+              img_alt = autolink_url:match "([^/]+)$" or autolink_url
+            end
+          end
           -- Obsidian embed: ![[file]] or ![[file|caption]]
           if not img_path then
             local embed = line:match "^%s*!%[%[(.-)%]%]%s*$"

--- a/lua/md-render/markdown.lua
+++ b/lua/md-render/markdown.lua
@@ -823,6 +823,48 @@ local function process_bare_urls(text, max_url_width, highlights, links)
       processed = processed .. "`"
       i = i + 1
     elseif not in_backtick then
+      -- CommonMark autolink: <https://example.com>. The angle brackets are
+      -- delimiters only and must not appear in the rendered output.
+      local handled_autolink = false
+      if text:sub(i, i) == "<" then
+        local _, lt_e, captured = text:find("^<(https?://[^>%s]+)>", i)
+        if captured then
+          handled_autolink = true
+          local start_col = #processed
+          local display_url
+          if vim.api.nvim_strwidth(captured) > max_url_width then
+            local target = max_url_width - vim.api.nvim_strwidth("…")
+            local current_width = 0
+            local byte_pos = 0
+            for char in captured:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
+              local char_width = vim.api.nvim_strwidth(char)
+              if current_width + char_width > target then
+                break
+              end
+              current_width = current_width + char_width
+              byte_pos = byte_pos + #char
+            end
+            display_url = captured:sub(1, byte_pos) .. "…"
+            -- Removed: leading '<' (1 byte at input pos i), truncated tail of URL
+            -- replaced by "…", and trailing '>' (1 byte at end).
+            table.insert(adjustments, { input_pos = i, delta = 1 })
+            table.insert(adjustments, {
+              input_pos = i + byte_pos,
+              delta = #captured - byte_pos - #"…",
+            })
+            table.insert(adjustments, { input_pos = i + 1 + #captured, delta = 1 })
+          else
+            display_url = captured
+            table.insert(adjustments, { input_pos = i, delta = 1 })
+            table.insert(adjustments, { input_pos = i + 1 + #captured, delta = 1 })
+          end
+          processed = processed .. display_url
+          table.insert(highlights, { col = start_col, end_col = start_col + #display_url, hl = "Underlined" })
+          table.insert(links, { col_start = start_col, col_end = start_col + #display_url, url = captured })
+          i = lt_e + 1
+        end
+      end
+      if not handled_autolink then
       local s, e = text:find("https?://[^%s%)<>\"]+", i)
       if s == i then
         local url_match = text:sub(s, e)
@@ -870,6 +912,7 @@ local function process_bare_urls(text, max_url_width, highlights, links)
         processed = processed .. text:sub(i, i)
         i = i + 1
       end
+      end -- if not handled_autolink
     else
       processed = processed .. text:sub(i, i)
       i = i + 1

--- a/tests/link_types_test.lua
+++ b/tests/link_types_test.lua
@@ -113,6 +113,67 @@ test("standard link [text](https://...) has external URL", function()
   assert_match(links[1].url, "^https://", "external link: URL is https")
 end)
 
+-- CommonMark autolink: <https://...>
+-- Angle brackets are delimiters and must not appear in rendered output.
+
+test("autolink <URL> strips angle brackets and registers link", function()
+  local rendered, _, links = Markdown.render("<https://example.com>")
+  assert_eq(rendered, "https://example.com", "autolink: brackets stripped")
+  assert_eq(#links, 1, "autolink: one link")
+  assert_eq(links[1].url, "https://example.com", "autolink: URL preserved")
+  assert_eq(links[1].col_start, 0, "autolink: link starts at col 0")
+  assert_eq(links[1].col_end, #"https://example.com", "autolink: link ends at URL end")
+end)
+
+test("autolink coexists with surrounding text", function()
+  local rendered, _, links = Markdown.render("See <https://example.com> for more")
+  assert_eq(rendered, "See https://example.com for more", "inline autolink: brackets stripped")
+  assert_eq(#links, 1, "inline autolink: one link")
+  assert_eq(links[1].col_start, 4, "inline autolink: starts after 'See '")
+  assert_eq(links[1].url, "https://example.com", "inline autolink: URL preserved")
+end)
+
+test("autolink long URL is truncated for display but full URL kept in metadata", function()
+  local long = "https://github.com/user-attachments/assets/4c042f5c-fb7f-4a1e-a3d9-e2ab43ae215a-very-long-url"
+  local rendered, _, links = Markdown.render("<" .. long .. ">")
+  assert_eq(rendered:sub(-3), "…", "autolink: truncated display ends with ellipsis")
+  assert_eq(#links, 1, "autolink: one link")
+  assert_eq(links[1].url, long, "autolink: full URL preserved in metadata")
+end)
+
+-- Standalone <URL> on a line that points at GitHub's user-attachments CDN
+-- routes through image_placements so the existing download + magic-byte
+-- detection can render it as image/video (mirrors github.com behavior).
+
+test("standalone autolink to user-attachments registers image placement", function()
+  local ContentBuilder = require("md-render.content_builder").ContentBuilder
+  local b = ContentBuilder.new()
+  local url = "https://github.com/user-attachments/assets/4c042f5c-fb7f-4a1e-a3d9-e2ab43ae215a"
+  b:render_document({ "<" .. url .. ">" }, { max_width = 80, indent = "  " })
+  local result = b:result()
+  local found
+  for _, p in ipairs(result.image_placements or {}) do
+    if p.src_url == url then found = p; break end
+  end
+  assert_eq(found ~= nil, true, "user-attachments autolink: image placement registered")
+  assert_eq(found and found.src_url, url, "user-attachments autolink: src_url preserved")
+end)
+
+test("standalone autolink to non-attachments URL does NOT become a placement", function()
+  local ContentBuilder = require("md-render.content_builder").ContentBuilder
+  local b = ContentBuilder.new()
+  b:render_document({ "<https://example.com/page>" }, { max_width = 80, indent = "  " })
+  local result = b:result()
+  for _, p in ipairs(result.image_placements or {}) do
+    if p.src_url == "https://example.com/page" then
+      fail_count = fail_count + 1
+      print("FAIL: non-attachments autolink should not become an image placement")
+      return
+    end
+  end
+  pass_count = pass_count + 1
+end)
+
 -- Highlight tests for wikilinks
 
 test("wikilink [[#heading]] uses MdRenderLinkAnchor highlight", function()


### PR DESCRIPTION
## Summary
- Inline CommonMark autolink (`<https://example.com>`) now strips the angle brackets in the rendered output and registers the URL as a clickable link (previously the brackets leaked through as literals).
- A standalone `<URL>` line pointing at GitHub's `user-attachments` CDN is routed through the image pipeline so it inlines as video/image — same behavior as github.com. Existing `download_async` + magic-byte detection + `ffprobe` handles the actual rendering. Restricted to that CDN to avoid stuck "Loading..." placeholders for non-media URLs.

## Test plan
- [x] `make test` (515 passed, 0 failed; +5 new autolink tests in `tests/link_types_test.lua`)
- [x] Loaded `~/.local/share/nvim/lazy/undo-glow.nvim/README.md` (which has 19 `<https://github.com/user-attachments/assets/...>` lines): all 19 register as image_placements with `src_url` populated
- [ ] Manual: open the same README with `:MdRender` in a Kitty-graphics-capable terminal and confirm the videos play

🤖 Generated with [Claude Code](https://claude.com/claude-code)