### PR TITLE
fix(highlight): bump MdRenderInlineCode bg blend from 0.18 to 0.3

### DIFF
--- a/lua/md-render/init.lua
+++ b/lua/md-render/init.lua
@@ -125,7 +125,7 @@ function M.setup_inline_code_highlight()
   local normal_bg = normal_hl.bg or 0x1e1e2e
   local comment_hl = vim.api.nvim_get_hl(0, { name = "Comment", link = false })
   local tint = comment_hl.fg or 0x888888
-  local bg = blend_color(tint, normal_bg, 0.18)
+  local bg = blend_color(tint, normal_bg, 0.3)
   local string_hl = vim.api.nvim_get_hl(0, { name = "String", link = false })
   if string_hl.fg then
     vim.api.nvim_set_hl(0, "MdRenderInlineCode", { fg = string_hl.fg, bg = bg, default = true })


### PR DESCRIPTION
## Summary
- 0.18 was too subtle to clearly tell inline code from surrounding prose. 0.3 gives a noticeably visible bg without becoming distracting.

In a catppuccin-like setup the bg goes from `#2c2d3e` (barely distinct from Normal `#1e1e2e`) to `#353748` (clearly distinct).

## Test plan
- [x] `make test` (no behavioral change beyond the bg value)
- [ ] Manual: open a README with many backtick spans and confirm the bg is now clearly visible but not loud

🤖 Generated with [Claude Code](https://claude.com/claude-code)