### PR TITLE
fix(highlight): carry over bg from treesitter heading hl

### DIFF
--- a/lua/md-render/init.lua
+++ b/lua/md-render/init.lua
@@ -31,14 +31,21 @@ local function blend_color(fg, bg, alpha)
   return bit.lshift(r, 16) + bit.lshift(g, 8) + b
 end
 
---- Set up heading highlight groups (MdRenderH1..MdRenderH6)
+--- Set up heading highlight groups (MdRenderH1..MdRenderH6).
+--- All attributes from `@markup.heading.<level>.markdown` are carried over
+--- (including `bg`, `italic`, `underline`, etc.) so colorschemes that paint
+--- a heading background (e.g. tokyonight) render the same way in the
+--- preview buffer as in the source buffer. `bold` is forced as a fallback
+--- for colorschemes that omit it.
 function M.setup_heading_highlights()
   for level = 1, 6 do
     local hl_name = "MdRenderH" .. level
     local ts_name = "@markup.heading." .. level .. ".markdown"
     local ts_hl = vim.api.nvim_get_hl(0, { name = ts_name, link = false })
-    if ts_hl.fg then
-      vim.api.nvim_set_hl(0, hl_name, { fg = ts_hl.fg, bold = true, default = true })
+    if ts_hl.fg or ts_hl.bg then
+      ts_hl.bold = true
+      ts_hl.default = true
+      vim.api.nvim_set_hl(0, hl_name, ts_hl)
     else
       vim.api.nvim_set_hl(0, hl_name, { link = "Title", default = true })
     end


### PR DESCRIPTION
## Summary
- `setup_heading_highlights` only copied `fg` from `@markup.heading.<level>.markdown`, silently dropping `bg` (and other attributes like `italic`/`underline`).
- Colorschemes that paint a heading background — tokyonight is the obvious one, with a distinct bg per level — rendered with bg in the source buffer but not in the md-render preview buffer.
- Now the full resolved attribute table is carried over. `bold = true` is still forced as a fallback for colorschemes that omit it.

Verified under tokyonight: all 6 `MdRenderH<level>` groups now resolve to both `fg` and `bg` (e.g. `H3 = fg=#c3e88d bg=#32383f bold=true`).

## Test plan
- [x] `make test` (no behavioral test changes; 515 passed)
- [ ] Manual: open a README under tokyonight in `:MdRenderSplit` and confirm headings now have a bg matching the source side

🤖 Generated with [Claude Code](https://claude.com/claude-code)