### PR TITLE
fix(auto): make :MdRender auto a true toggle by swapping back to source on off

### DIFF
--- a/doc/md-render.txt
+++ b/doc/md-render.txt
@@ -218,9 +218,12 @@ still registered as deprecated aliases — see |md-render-deprecated-commands|.
 	  immediately, and registers `InsertEnter` / `InsertLeave` autocmds
 	  that swap to source on entry and back to render on leave.
 	- `:MdRender auto off` removes the autocmds and the buffer marker.
-	  The displayed mode is left unchanged.
+	  If the current window is showing the render view of this buffer,
+	  it also swaps back to source so the buffer ends up in the same
+	  state it had before `:MdRender auto on`.
 	- `:MdRender auto toggle`, or `:MdRender auto` with no second arg,
-	  toggles between on and off.
+	  toggles between on and off.  Calling it twice returns the buffer
+	  to its original (auto-off, source displayed) state.
 
 	The plugin does not register a |FileType| autocmd of its own.  To
 	enable auto mode for every Markdown buffer, add one yourself: >vim
@@ -531,8 +534,10 @@ MdPreview.auto_on({opts}) ~
 
 							   *MdPreview.auto_off()*
 MdPreview.auto_off() ~
-	[EXPERIMENTAL] Disable auto-toggle for the current buffer.  The
-	displayed mode is left as-is.  See |:MdRender-auto|.
+	[EXPERIMENTAL] Disable auto-toggle for the current buffer.  If the
+	current window is showing this buffer's render view, it also swaps
+	back to source so the post-`auto_off` state matches what existed
+	before |MdPreview.auto_on()|.  See |:MdRender-auto|.
 
 							*MdPreview.auto_toggle()*
 MdPreview.auto_toggle({opts}) ~

--- a/lua/md-render/preview.lua
+++ b/lua/md-render/preview.lua
@@ -1954,7 +1954,9 @@ function MdPreview.auto_on(opts)
   end
 end
 
---- Disable auto-toggle for the current buffer; leave the displayed mode untouched.
+--- Disable auto-toggle for the current buffer and, if the current window is
+--- showing this buffer's render view, swap back to source so a single
+--- `auto_off` (or a second `auto_toggle`) returns to the pre-`auto_on` state.
 function MdPreview.auto_off()
   local bufnr = get_auto_target_buf()
   if not vim.b[bufnr].md_render_auto then return end
@@ -1970,6 +1972,12 @@ function MdPreview.auto_off()
 
   local session = _toggle_sessions[bufnr]
   if session then uninstall_auto_insert_keymaps(session.buf) end
+
+  local win = vim.api.nvim_get_current_win()
+  local win_state = get_win_state(win)
+  if win_state and win_state.mode == "render" and win_state.source_buf == bufnr then
+    MdPreview.toggle()
+  end
 end
 
 --- Flip auto-toggle state for the current buffer.

--- a/tests/toggle_test.lua
+++ b/tests/toggle_test.lua
@@ -607,14 +607,14 @@ test("auto-transition to render swaps source → render after 50ms", function()
 end)
 
 -- ----------------------------------------------------------------------
--- Test 18: auto_off clears autocmds and leaves displayed mode untouched
+-- Test 18: auto_off clears autocmds and restores source display
 -- ----------------------------------------------------------------------
-test("auto_off clears autocmds and preserves displayed mode", function()
+test("auto_off clears autocmds and swaps render back to source", function()
   local source = setup_md_buffer({ "# Hello" })
   local win = vim.api.nvim_get_current_win()
 
   preview.auto_on()
-  local before_buf = vim.api.nvim_win_get_buf(win)
+  assert_false(vim.api.nvim_win_get_buf(win) == source, "precondition: render after auto_on")
 
   preview.auto_off()
 
@@ -629,7 +629,48 @@ test("auto_off clears autocmds and preserves displayed mode", function()
   })
   assert_true(not ok or #autocmds == 0, "no auto autocmds should remain")
 
-  assert_eq(vim.api.nvim_win_get_buf(win), before_buf, "displayed mode should be unchanged")
+  assert_eq(vim.api.nvim_win_get_buf(win), source, "should be back on source after auto_off")
+
+  cleanup_buffer(source)
+end)
+
+-- ----------------------------------------------------------------------
+-- Test 18b: auto_toggle twice returns to the original (source, auto-off) state
+-- ----------------------------------------------------------------------
+test("auto_toggle twice returns to original source/auto-off state", function()
+  local source = setup_md_buffer({ "# Hello" })
+  local win = vim.api.nvim_get_current_win()
+
+  assert_eq(vim.api.nvim_win_get_buf(win), source, "precondition: source")
+  assert_eq(vim.b[source].md_render_auto, nil, "precondition: auto off")
+
+  preview.auto_toggle()
+  assert_eq(vim.b[source].md_render_auto, true, "after 1st toggle: auto on")
+  assert_false(vim.api.nvim_win_get_buf(win) == source, "after 1st toggle: render displayed")
+
+  preview.auto_toggle()
+  assert_eq(vim.b[source].md_render_auto, nil, "after 2nd toggle: auto off")
+  assert_eq(vim.api.nvim_win_get_buf(win), source, "after 2nd toggle: source displayed")
+
+  cleanup_buffer(source)
+end)
+
+-- ----------------------------------------------------------------------
+-- Test 18c: auto_off leaves displayed mode unchanged when not showing render
+-- ----------------------------------------------------------------------
+test("auto_off does not swap when current window is not showing render", function()
+  local source = setup_md_buffer({ "# Hello" })
+  local win = vim.api.nvim_get_current_win()
+
+  preview.auto_on()
+  -- Manually swap back to source so auto_off has nothing to swap.
+  preview.toggle()
+  assert_eq(vim.api.nvim_win_get_buf(win), source, "precondition: source displayed")
+
+  preview.auto_off()
+
+  assert_eq(vim.b[source].md_render_auto, nil, "b:md_render_auto should be cleared")
+  assert_eq(vim.api.nvim_win_get_buf(win), source, "should still be on source after auto_off")
 
   cleanup_buffer(source)
 end)


### PR DESCRIPTION
## Summary

- `:MdRender auto` (= `auto_toggle`) now returns to the pre-toggle state when called twice.
- `MdPreview.auto_off` swaps the current window back to source when it's showing this buffer's render view, in addition to clearing `b:md_render_auto` / autocmds / Insert-entry keymaps.
- Documented behavior in `:help :MdRender-auto` and `:help MdPreview.auto_off()` updated to match.

## Why

The previous `auto_off` was deliberately documented as "leaves the displayed mode untouched". That made `:MdRender auto` (toggle) asymmetric: source → render on the first call, but render stays render on the second call (only the autocmd is gone). Users reasonably expected a toggle to be reversible. Since auto mode is still marked `[EXPERIMENTAL]`, tightening the contract to be symmetric is preferable to keeping the surprise.

`auto_toggle` itself is unchanged; it inherits the fix from `auto_off`.

## Test plan

- [x] `make test` — all 525 tests pass (toggle_test grew from 147 → 149).
- [x] New tests cover:
  - `auto_off` swaps render back to source (Test 18, rewritten).
  - Two `auto_toggle` calls return to the original `(source, auto-off)` state (Test 18b).
  - `auto_off` is a no-op for display when the current window is already showing source (Test 18c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)