### PR TITLE
style: add .stylua.toml and format the codebase

### DIFF
--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,10 @@
+column_width = 120
+line_endings = "Unix"
+# Neovim runs LuaJIT; pin the dialect so goto/label syntax (::continue::,
+# ::finalize::) parses unambiguously instead of clashing with Luau labels.
+syntax = "LuaJIT"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"
+no_call_parentheses = true
+collapse_simple_statement = "ConditionalOnly"

--- a/lua/md-render/command.lua
+++ b/lua/md-render/command.lua
@@ -26,7 +26,7 @@ function M.dispatch(args)
   elseif sub == "toggle" then
     p.toggle()
   elseif sub == "split" then
-    p.split({ mods = args.smods })
+    p.split { mods = args.smods }
   elseif sub == "demo" then
     p.show_demo()
   elseif sub == "auto" then
@@ -38,10 +38,7 @@ function M.dispatch(args)
     elseif a == "toggle" then
       p.auto_toggle()
     else
-      vim.notify(
-        "MdRender auto: unknown argument '" .. a .. "' (expected on|off|toggle)",
-        vim.log.levels.WARN
-      )
+      vim.notify("MdRender auto: unknown argument '" .. a .. "' (expected on|off|toggle)", vim.log.levels.WARN)
     end
   else
     vim.notify(
@@ -57,16 +54,16 @@ end
 ---@param cmdline string The full command line so far.
 ---@return string[]
 function M.complete(arglead, cmdline, _cursorpos)
-  local tail = cmdline:match("MdRender%s+(.*)$") or ""
+  local tail = cmdline:match "MdRender%s+(.*)$" or ""
   local before = tail:sub(1, #tail - #arglead)
   local n = 0
-  for _ in before:gmatch("%S+") do
+  for _ in before:gmatch "%S+" do
     n = n + 1
   end
   local list
   if n == 0 then
     list = SUBCOMMANDS
-  elseif n == 1 and before:match("^%s*auto%s+$") then
+  elseif n == 1 and before:match "^%s*auto%s+$" then
     list = AUTO_ARGS
   else
     return {}

--- a/lua/md-render/content_builder.lua
+++ b/lua/md-render/content_builder.lua
@@ -99,9 +99,7 @@ end
 function ContentBuilder:add_line(text, hl_groups)
   table.insert(self.lines, text)
   table.insert(self.source_line_map, self._current_source_line)
-  if hl_groups then
-    table.insert(self.highlights, { line = #self.lines - 1, groups = hl_groups })
-  end
+  if hl_groups then table.insert(self.highlights, { line = #self.lines - 1, groups = hl_groups }) end
 end
 
 ---@param label string
@@ -141,7 +139,7 @@ end
 local function detect_urls_in_code_line(self, raw_line, prefix_len, content_byte_end)
   local pos = 1
   while true do
-    local ms, me = raw_line:find("https?://[^%s%)<>\"]+", pos)
+    local ms, me = raw_line:find('https?://[^%s%)<>"]+', pos)
     if not ms then break end
     local url = raw_line:sub(ms, me):gsub("[.,;:!?*~]+$", "")
     -- Strip trailing non-ASCII symbols (e.g. ⏎, →) that are not valid in URLs.
@@ -200,15 +198,23 @@ local wrap_words = wrap_mod.wrap_words
 ---@param list_prefix_len? integer Byte length of list marker prefix (0 if none)
 ---@param list_cont_len? integer Display width of list marker for continuation indent (0 if none)
 ---@return MdRender.Highlight.Group[][] per_line_highlights Array of highlight lists, one per wrapped line
-local function distribute_highlights(md_highlights, wrapped_lines, line_starts, indent, quote_prefix, content_offset, list_prefix_len, list_cont_len)
+local function distribute_highlights(
+  md_highlights,
+  wrapped_lines,
+  line_starts,
+  indent,
+  quote_prefix,
+  content_offset,
+  list_prefix_len,
+  list_cont_len
+)
   list_prefix_len = list_prefix_len or 0
   list_cont_len = list_cont_len or list_prefix_len
   local per_line = {}
   for idx, wline in ipairs(wrapped_lines) do
     local line_start_pos = line_starts[idx]
     local lm_len = idx == 1 and list_prefix_len or list_cont_len
-    local line_prefix = (quote_prefix ~= "" and (indent .. quote_prefix) or indent)
-        .. string.rep(" ", lm_len)
+    local line_prefix = (quote_prefix ~= "" and (indent .. quote_prefix) or indent) .. string.rep(" ", lm_len)
     local line_hls = {}
 
     -- Add FloatBorder highlight for blockquote prefix on continuation lines
@@ -272,15 +278,24 @@ end
 ---@param list_prefix_len? integer Byte length of list marker prefix (0 if none)
 ---@param list_cont_len? integer Display width of list marker for continuation indent (0 if none)
 ---@return MdRender.LinkMetadata[] link_entries
-local function distribute_links(md_links, wrapped_lines, line_starts, indent, quote_prefix, content_offset, base_line, list_prefix_len, list_cont_len)
+local function distribute_links(
+  md_links,
+  wrapped_lines,
+  line_starts,
+  indent,
+  quote_prefix,
+  content_offset,
+  base_line,
+  list_prefix_len,
+  list_cont_len
+)
   list_prefix_len = list_prefix_len or 0
   list_cont_len = list_cont_len or list_prefix_len
   local entries = {}
   for idx, wline in ipairs(wrapped_lines) do
     local line_start_pos = line_starts[idx]
     local lm_len = idx == 1 and list_prefix_len or list_cont_len
-    local line_prefix = (quote_prefix ~= "" and (indent .. quote_prefix) or indent)
-        .. string.rep(" ", lm_len)
+    local line_prefix = (quote_prefix ~= "" and (indent .. quote_prefix) or indent) .. string.rep(" ", lm_len)
 
     for _, link in ipairs(md_links) do
       local link_start = link.col_start - content_offset
@@ -311,7 +326,15 @@ end
 ---@param max_width integer
 ---@param quote_prefix string
 ---@param list_marker? string
-function ContentBuilder:add_wrapped_markdown(rendered_text, md_highlights, md_links, indent, max_width, quote_prefix, list_marker)
+function ContentBuilder:add_wrapped_markdown(
+  rendered_text,
+  md_highlights,
+  md_links,
+  indent,
+  max_width,
+  quote_prefix,
+  list_marker
+)
   local wrap_text = rendered_text
   local content_offset = 0
   if quote_prefix ~= "" then
@@ -330,17 +353,32 @@ function ContentBuilder:add_wrapped_markdown(rendered_text, md_highlights, md_li
   end
 
   local content_max_width = max_width
-  if quote_prefix ~= "" then
-    content_max_width = max_width - vim.api.nvim_strwidth(quote_prefix)
-  end
-  if list_cont_len > 0 then
-    content_max_width = content_max_width - list_cont_len
-  end
+  if quote_prefix ~= "" then content_max_width = max_width - vim.api.nvim_strwidth(quote_prefix) end
+  if list_cont_len > 0 then content_max_width = content_max_width - list_cont_len end
 
   local wrapped_lines, line_starts = wrap_words(wrap_text, content_max_width)
-  local per_line_hls = distribute_highlights(md_highlights, wrapped_lines, line_starts, indent, quote_prefix, content_offset, list_prefix_len, list_cont_len)
+  local per_line_hls = distribute_highlights(
+    md_highlights,
+    wrapped_lines,
+    line_starts,
+    indent,
+    quote_prefix,
+    content_offset,
+    list_prefix_len,
+    list_cont_len
+  )
   local base_line = #self.lines
-  local link_entries = distribute_links(md_links, wrapped_lines, line_starts, indent, quote_prefix, content_offset, base_line, list_prefix_len, list_cont_len)
+  local link_entries = distribute_links(
+    md_links,
+    wrapped_lines,
+    line_starts,
+    indent,
+    quote_prefix,
+    content_offset,
+    base_line,
+    list_prefix_len,
+    list_cont_len
+  )
 
   local list_prefix = list_marker or ""
   local list_continuation = string.rep(" ", list_cont_len)
@@ -397,7 +435,16 @@ end
 ---   source row offset. When false/nil (HTML tables, where the source
 ---   isn't a per-row enumeration), all rows inherit the caller's
 ---   _current_source_line as-is.
-function ContentBuilder:add_table(table_lines, indent, max_width, repo_base_url, autolinks, expanded, buf_dir, per_row_source)
+function ContentBuilder:add_table(
+  table_lines,
+  indent,
+  max_width,
+  repo_base_url,
+  autolinks,
+  expanded,
+  buf_dir,
+  per_row_source
+)
   local markdown_table = require "md-render.markdown_table"
   local parsed = markdown_table.parse(table_lines, repo_base_url, autolinks)
   if not parsed then
@@ -472,9 +519,7 @@ function ContentBuilder:_emit_image_header(indent, img_icon, icon_hl, display_na
       local hls = {
         { col = icon_end, end_col = #header, hl = name_hl },
       }
-      if icon_hl then
-        table.insert(hls, 1, { col = icon_start, end_col = icon_end, hl = icon_hl })
-      end
+      if icon_hl then table.insert(hls, 1, { col = icon_start, end_col = icon_end, hl = icon_hl }) end
       self:add_line(header, hls)
     else
       local cont_pad = string.rep(" ", cont_width)
@@ -522,15 +567,13 @@ function ContentBuilder:add_markdown_line(text, indent, max_width, repo_base_url
   -- Register heading anchor (slug → rendered line)
   if heading_content then
     local slug = markdown.heading_slug(heading_content)
-    if slug ~= "" then
-      self.heading_anchors[slug] = lines_before_fn
-    end
+    if slug ~= "" then self.heading_anchors[slug] = lines_before_fn end
   end
 
   -- Register footnote ref anchors (first occurrence per label)
   for _, link in ipairs(self.link_metadata) do
     if link.line >= lines_before_fn then
-      local label = link.url and link.url:match("^#footnote%-def%-(.+)$")
+      local label = link.url and link.url:match "^#footnote%-def%-(.+)$"
       if label and not self.footnote_anchors["footnote-ref-" .. label] then
         self.footnote_anchors["footnote-ref-" .. label] = link.line
       end
@@ -554,9 +597,7 @@ function ContentBuilder:apply_alert_styling(lines_before, lines_after, alert_typ
     if hl_info.line >= lines_before and hl_info.line < lines_after then
       -- Replace FloatBorder highlights with alert-colored border
       for _, group in ipairs(hl_info.groups) do
-        if group.hl == "FloatBorder" then
-          group.hl = alert_hl
-        end
+        if group.hl == "FloatBorder" then group.hl = alert_hl end
       end
 
       -- On header line, add alert highlight for content after the bar
@@ -571,9 +612,7 @@ function ContentBuilder:apply_alert_styling(lines_before, lines_after, alert_typ
               break
             end
           end
-          if bar_end > 0 then
-            table.insert(hl_info.groups, { col = bar_end, end_col = #line_text, hl = alert_hl })
-          end
+          if bar_end > 0 then table.insert(hl_info.groups, { col = bar_end, end_col = #line_text, hl = alert_hl }) end
         end
       end
 
@@ -605,9 +644,7 @@ end
 ---@param icon string single icon character
 ---@return string
 local function pad_icon(icon)
-  if vim.api.nvim_strwidth(icon) == 1 then
-    return icon .. " "
-  end
+  if vim.api.nvim_strwidth(icon) == 1 then return icon .. " " end
   return icon
 end
 
@@ -618,11 +655,9 @@ local get_file_icon = icons.get_file_icon
 ---@param line_idx integer 0-indexed rendered line
 ---@param is_collapsed boolean
 function ContentBuilder:add_fold_indicator(line_idx, is_collapsed)
-  local indicator = is_collapsed and (" " .. pad_icon("󰅂")) or (" " .. pad_icon("󰅀"))
+  local indicator = is_collapsed and (" " .. pad_icon "󰅂") or (" " .. pad_icon "󰅀")
   local line = self.lines[line_idx + 1]
-  if not line then
-    return
-  end
+  if not line then return end
 
   -- Append indicator at the end of the line (no highlight shifts needed)
   self.lines[line_idx + 1] = line .. indicator
@@ -646,20 +681,38 @@ end
 
 --- Tags already handled by render_document's main loop (skip in preprocessing)
 local HTML_SKIP_TAGS = {
-  details = true, summary = true,
+  details = true,
+  summary = true,
   hr = true,
   figure = true,
   p = true,
-  div = true, span = true,
+  div = true,
+  span = true,
   dl = true,
-  table = true, tr = true, td = true, th = true, thead = true, tbody = true,
+  table = true,
+  tr = true,
+  td = true,
+  th = true,
+  thead = true,
+  tbody = true,
 }
 
 --- HTML void elements (self-closing, no end tag) — must not accumulate lines.
 local HTML_VOID_ELEMENTS = {
-  area = true, base = true, br = true, col = true, embed = true,
-  hr = true, img = true, input = true, link = true, meta = true,
-  param = true, source = true, track = true, wbr = true,
+  area = true,
+  base = true,
+  br = true,
+  col = true,
+  embed = true,
+  hr = true,
+  img = true,
+  input = true,
+  link = true,
+  meta = true,
+  param = true,
+  source = true,
+  track = true,
+  wbr = true,
 }
 
 --- Convert accumulated HTML table lines into pipe-table format lines.
@@ -686,14 +739,10 @@ local function html_table_to_pipe(html_lines)
       local cell = content:gsub("^%s+", ""):gsub("%s+$", "")
       table.insert(cells, { text = cell, is_header = tag == "th" })
     end
-    if #cells > 0 then
-      table.insert(rows, { cells = cells, aligns = aligns })
-    end
+    if #cells > 0 then table.insert(rows, { cells = cells, aligns = aligns }) end
   end
 
-  if #rows == 0 then
-    return {}
-  end
+  if #rows == 0 then return {} end
 
   -- Determine column count
   local num_cols = 0
@@ -703,9 +752,7 @@ local function html_table_to_pipe(html_lines)
 
   -- Determine if first row is a header row
   local has_header = false
-  if rows[1] then
-    has_header = rows[1].cells[1] and rows[1].cells[1].is_header
-  end
+  if rows[1] then has_header = rows[1].cells[1] and rows[1].cells[1].is_header end
 
   -- Build alignment from header or first data row
   local col_aligns = {}
@@ -827,9 +874,7 @@ local function join_paragraph_continuations(lines, src_indices)
   for idx, line in ipairs(lines) do
     local src = src_indices[idx]
     -- Track code fences
-    if line:match "^```" or line:match "^~~~" then
-      in_code = not in_code
-    end
+    if line:match "^```" or line:match "^~~~" then in_code = not in_code end
 
     -- Track multi-line HTML comments
     if not in_code then
@@ -838,9 +883,7 @@ local function join_paragraph_continuations(lines, src_indices)
         flush_para()
         table.insert(result, line)
         table.insert(result_indices, src)
-        if line:match "%-%->" then
-          in_html_comment = false
-        end
+        if line:match "%-%->" then in_html_comment = false end
         goto next_line
       end
       if line:match "^%s*<!%-%-" and not line:match "%-%->%s*$" then
@@ -906,9 +949,7 @@ local function preprocess_multiline_html(lines, src_indices)
         accum = nil
       end
     else
-      if l:match "^```" then
-        in_code = not in_code
-      end
+      if l:match "^```" then in_code = not in_code end
       if not in_code then
         local tag_name = l:match "^%s*<(%a%w*)[%s>]"
         if tag_name then
@@ -990,7 +1031,7 @@ function ContentBuilder:render_document(lines, opts)
   local fold_state = opts.fold_state or {}
   local expand_state = opts.expand_state or {}
   local source_line_offset = opts.source_line_offset or 0
-  local buf_dir = opts.buf_dir or vim.fn.expand("%:p:h")
+  local buf_dir = opts.buf_dir or vim.fn.expand "%:p:h"
 
   local in_code_block = false
   local code_block_lang = nil
@@ -1055,9 +1096,7 @@ function ContentBuilder:render_document(lines, opts)
       -- line so add_table's emissions land in source_line_map under the
       -- table itself, then restore for the caller.
       local saved_src_line = self._current_source_line
-      if table_buf_start_idx then
-        self._current_source_line = table_buf_start_idx + source_line_offset
-      end
+      if table_buf_start_idx then self._current_source_line = table_buf_start_idx + source_line_offset end
       self:add_table(table_buf, indent, max_width, repo_base_url, autolinks, tbl_expanded or false, buf_dir, true)
       self._current_source_line = saved_src_line
       local lines_added = #self.lines - lines_before_tbl
@@ -1095,9 +1134,7 @@ function ContentBuilder:render_document(lines, opts)
 
     local det_lines_before = #self.lines
     local det_icon = is_collapsed and "▶ " or "▼ "
-    local det_rendered, det_hls, det_links = markdown.render(
-      summary_text, repo_base_url, autolinks, ref_links
-    )
+    local det_rendered, det_hls, det_links = markdown.render(summary_text, repo_base_url, autolinks, ref_links)
 
     local det_icon_len = #det_icon
     for _, hl in ipairs(det_hls) do
@@ -1120,9 +1157,7 @@ function ContentBuilder:render_document(lines, opts)
       collapsed = is_collapsed,
     })
 
-    if is_collapsed then
-      skip_details_body = true
-    end
+    if is_collapsed then skip_details_body = true end
 
     details_summary_rendered = true
     lines_shown = lines_shown + (#self.lines - det_lines_before)
@@ -1143,9 +1178,7 @@ function ContentBuilder:render_document(lines, opts)
       if hl_info.line >= from_line and hl_info.line < to_line then
         for _, group in ipairs(hl_info.groups) do
           group.col = group.col + prefix_len
-          if group.end_col >= 0 then
-            group.end_col = group.end_col + prefix_len
-          end
+          if group.end_col >= 0 then group.end_col = group.end_col + prefix_len end
         end
         table.insert(hl_info.groups, 1, {
           col = indent_len,
@@ -1202,49 +1235,41 @@ function ContentBuilder:render_document(lines, opts)
     end
 
     -- Skip reference link definition lines
-    if not in_code_block and markdown.is_reference_link_def(line) then
-      goto continue
-    end
+    if not in_code_block and markdown.is_reference_link_def(line) then goto continue end
 
     -- Skip footnote definition lines (rendered in footnote section at end)
-    if not in_code_block and markdown.is_footnote_def(line) then
-      goto continue
-    end
+    if not in_code_block and markdown.is_footnote_def(line) then goto continue end
 
     -- Handle <div>/<span> wrapper tags (outside code blocks)
     -- Strip wrapper tags and let inner content fall through to normal processing.
     if not in_code_block and not in_callout_code_block then
       -- Closing </div> or </span> on its own line
-      if line:match "^%s*</div>%s*$" or line:match "^%s*</span>%s*$" then
-        goto continue
-      end
+      if line:match "^%s*</div>%s*$" or line:match "^%s*</span>%s*$" then goto continue end
       -- Opening <div>/<span> with no content on the same line
-      if (line:match "^%s*<div>%s*$" or line:match "^%s*<div%s[^>]*>%s*$")
-        or (line:match "^%s*<span>%s*$" or line:match "^%s*<span%s[^>]*>%s*$") then
+      if
+        (line:match "^%s*<div>%s*$" or line:match "^%s*<div%s[^>]*>%s*$")
+        or (line:match "^%s*<span>%s*$" or line:match "^%s*<span%s[^>]*>%s*$")
+      then
         goto continue
       end
       -- Single-line <div>...</div>: extract inner content
       local div_inner = line:match "^%s*<div[^>]*>%s*(.-)%s*</div>%s*$"
       if div_inner and div_inner:match "%S" then
-        line = div_inner
-        -- Fall through with extracted content
+        line = div_inner -- Fall through with extracted content
       end
       -- Single-line <span>...</span>: extract inner content
       local span_inner = line:match "^%s*<span[^>]*>%s*(.-)%s*</span>%s*$"
       if span_inner and span_inner:match "%S" then
-        line = span_inner
-        -- Fall through with extracted content
+        line = span_inner -- Fall through with extracted content
       end
       -- Opening <div>/<span> with content after the tag (no closing on same line)
       local div_rest = line:match "^%s*<div[^>]*>%s*(.+)$"
       if div_rest and not line:match "</div>" then
-        line = div_rest
-        -- Fall through with extracted content
+        line = div_rest -- Fall through with extracted content
       end
       local span_rest = line:match "^%s*<span[^>]*>%s*(.+)$"
       if span_rest and not line:match "</span>" then
-        line = span_rest
-        -- Fall through with extracted content
+        line = span_rest -- Fall through with extracted content
       end
     end
 
@@ -1307,22 +1332,16 @@ function ContentBuilder:render_document(lines, opts)
       in_comment_block = not in_comment_block
       goto continue
     end
-    if in_comment_block then
-      goto continue
-    end
+    if in_comment_block then goto continue end
 
     -- Handle HTML comments (<!-- ... -->) outside code blocks
     if not in_code_block then
       if in_html_comment then
-        if line:match "%-%->" then
-          in_html_comment = false
-        end
+        if line:match "%-%->" then in_html_comment = false end
         goto continue
       end
       -- Single-line HTML comment
-      if line:match "^%s*<!%-%-.*%-%->%s*$" then
-        goto continue
-      end
+      if line:match "^%s*<!%-%-.*%-%->%s*$" then goto continue end
       -- Multi-line HTML comment start
       if line:match "^%s*<!%-%-" then
         in_html_comment = true
@@ -1349,9 +1368,7 @@ function ContentBuilder:render_document(lines, opts)
 
       -- Skip body of collapsed <details>
       if skip_details_body then
-        if line:match "^%s*<details" then
-          details_depth = details_depth + 1
-        end
+        if line:match "^%s*<details" then details_depth = details_depth + 1 end
         goto continue
       end
 
@@ -1374,9 +1391,7 @@ function ContentBuilder:render_document(lines, opts)
         local rest = line:match "^%s*<details.->(.+)$"
         if rest then
           local s = rest:match "<summary>(.-)</summary>"
-          if s then
-            render_details_summary(s ~= "" and s or "Details")
-          end
+          if s then render_details_summary(s ~= "" and s or "Details") end
         end
         goto continue
       end
@@ -1387,9 +1402,7 @@ function ContentBuilder:render_document(lines, opts)
           -- Accumulating multi-line summary
           local before = line:match "^(.-)</summary>%s*$"
           if before then
-            if before ~= "" then
-              table.insert(details_summary_parts, before)
-            end
+            if before ~= "" then table.insert(details_summary_parts, before) end
             in_details_summary = false
             local joined = table.concat(details_summary_parts, " ")
             render_details_summary(joined ~= "" and joined or "Details")
@@ -1411,9 +1424,7 @@ function ContentBuilder:render_document(lines, opts)
         if start_text then
           in_details_summary = true
           details_summary_parts = {}
-          if start_text ~= "" then
-            table.insert(details_summary_parts, start_text)
-          end
+          if start_text ~= "" then table.insert(details_summary_parts, start_text) end
           goto continue
         end
 
@@ -1440,9 +1451,7 @@ function ContentBuilder:render_document(lines, opts)
             -- Trigger line is </figure>; restore the figcaption's own
             -- source line so its render rows are attributed to it.
             local saved_src_line = self._current_source_line
-            if figure_caption_src then
-              self._current_source_line = figure_caption_src + source_line_offset
-            end
+            if figure_caption_src then self._current_source_line = figure_caption_src + source_line_offset end
             local rendered_text, md_highlights, md_links =
               markdown.render(figure_caption, repo_base_url, autolinks, ref_links, footnote_map)
             -- Apply Comment as the base highlight covering the whole caption
@@ -1540,8 +1549,7 @@ function ContentBuilder:render_document(lines, opts)
       -- Single-line <p>...</p>: extract inner content and process it
       local p_inner = line:match "^%s*<p[^>]*>%s*(.-)%s*</p>%s*$"
       if p_inner and p_inner:match "%S" then
-        line = p_inner
-        -- Fall through with extracted content
+        line = p_inner -- Fall through with extracted content
       end
     end
 
@@ -1589,9 +1597,7 @@ function ContentBuilder:render_document(lines, opts)
             rest = rest:match "^%s*<dd>.-</dd>%s*(.*)" or ""
           else
             dd_content = rest:match "^%s*<dd>(.*)"
-            if dd_content then
-              rest = ""
-            end
+            if dd_content then rest = "" end
           end
           if dd_content and dd_content ~= "" then
             local dd_indent = indent .. "  "
@@ -1614,9 +1620,7 @@ function ContentBuilder:render_document(lines, opts)
             lines_shown = lines_shown + (#self.lines - dd_lines_before)
           end
           -- If nothing matched, skip rest to avoid infinite loop
-          if not dt_content and not dd_content then
-            break
-          end
+          if not dt_content and not dd_content then break end
         end
         goto continue
       end
@@ -1659,9 +1663,7 @@ function ContentBuilder:render_document(lines, opts)
             local tbl_expanded = html_table_src_idx and expand_state[html_table_src_idx]
             -- Same source-line stamping rationale as flush_table above.
             local saved_src_line = self._current_source_line
-            if html_table_src_idx then
-              self._current_source_line = html_table_src_idx + source_line_offset
-            end
+            if html_table_src_idx then self._current_source_line = html_table_src_idx + source_line_offset end
             self:add_table(pipe_lines, indent, max_width, repo_base_url, autolinks, tbl_expanded or false)
             self._current_source_line = saved_src_line
             local tbl_lines_added = #self.lines - tbl_lines_before
@@ -1771,9 +1773,7 @@ function ContentBuilder:render_document(lines, opts)
       self:add_line(indent)
       lines_shown = lines_shown + 1
     end
-    if prev_was_hr and not is_blank then
-      prev_was_hr = false
-    end
+    if prev_was_hr and not is_blank then prev_was_hr = false end
 
     -- Accumulate table lines
     if is_table_line then
@@ -1807,9 +1807,7 @@ function ContentBuilder:render_document(lines, opts)
     end
 
     -- Collapse consecutive rendered blank lines (outside regular code blocks)
-    if not in_code_block and is_blank and prev_rendered_blank then
-      goto continue
-    end
+    if not in_code_block and is_blank and prev_rendered_blank then goto continue end
 
     -- Skip blank lines adjacent to headings (outside code blocks)
     if not in_code_block and not in_callout_code_block and is_blank then
@@ -1817,30 +1815,24 @@ function ContentBuilder:render_document(lines, opts)
       if not skip then
         for k = src_idx + 1, #lines do
           -- Skip blank lines, reference link definitions, and footnote definitions (not rendered)
-          if not lines[k]:match "^%s*$"
+          if
+            not lines[k]:match "^%s*$"
             and not markdown.is_reference_link_def(lines[k])
-            and not markdown.is_footnote_def(lines[k]) then
+            and not markdown.is_footnote_def(lines[k])
+          then
             -- Check ATX heading or setext heading (text followed by === or ---)
             skip = lines[k]:match "^#+%s+" ~= nil
-            if not skip then
-              skip = is_thematic_break(lines[k])
-            end
-            if not skip then
-              skip = lines[k]:match "^:::$" ~= nil
-            end
+            if not skip then skip = is_thematic_break(lines[k]) end
+            if not skip then skip = lines[k]:match "^:::$" ~= nil end
             if not skip and not lines[k]:match "^[#>%-%*`|%d]" then
               local kk = lines[k + 1]
-              if kk and (kk:match "^=+%s*$" or kk:match "^%-+%s*$") then
-                skip = true
-              end
+              if kk and (kk:match "^=+%s*$" or kk:match "^%-+%s*$") then skip = true end
             end
             break
           end
         end
       end
-      if skip then
-        goto continue
-      end
+      if skip then goto continue end
 
       -- Skip blank lines between list items of the same marker type (loose list → tight)
       if not skip and prev_list_marker_type then
@@ -1851,9 +1843,7 @@ function ContentBuilder:render_document(lines, opts)
             break
           end
         end
-        if next_marker_type and next_marker_type == prev_list_marker_type then
-          goto continue
-        end
+        if next_marker_type and next_marker_type == prev_list_marker_type then goto continue end
       end
     end
 
@@ -1869,23 +1859,27 @@ function ContentBuilder:render_document(lines, opts)
     end
 
     -- Indented code block: 4+ spaces, not in a list/blockquote/etc context
-    if not in_code_block and not in_math_block and not current_alert_type
-        and line:match "^    " and not line:match "^    [%-*+]%s" and not line:match "^    %d+[.)]%s"
-        and (in_indented_code or not prev_list_marker_type) then
+    if
+      not in_code_block
+      and not in_math_block
+      and not current_alert_type
+      and line:match "^    "
+      and not line:match "^    [%-*+]%s"
+      and not line:match "^    %d+[.)]%s"
+      and (in_indented_code or not prev_list_marker_type)
+    then
       in_indented_code = true
       local code_content = line:sub(5) -- strip 4-space indent
       local indented_line = indent .. code_content
       local display_width = vim.api.nvim_strwidth(indented_line)
       local ib_lines_before = #self.lines
       if display_width > max_width then
-        local target = max_width - vim.api.nvim_strwidth("…")
+        local target = max_width - vim.api.nvim_strwidth "…"
         local current_width = 0
         local byte_pos = 0
         for char in indented_line:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
           local char_width = vim.api.nvim_strwidth(char)
-          if current_width + char_width > target then
-            break
-          end
+          if current_width + char_width > target then break end
           current_width = current_width + char_width
           byte_pos = byte_pos + #char
         end
@@ -1925,8 +1919,8 @@ function ContentBuilder:render_document(lines, opts)
         in_qiita_note = true
         -- Map Qiita note types to existing alert style keys
         local qiita_map = {
-          info  = { style = "NOTE",    icon = "󰋽", label = "Note" },
-          warn  = { style = "WARNING", icon = "󰀪", label = "Warning" },
+          info = { style = "NOTE", icon = "󰋽", label = "Note" },
+          warn = { style = "WARNING", icon = "󰀪", label = "Warning" },
           alert = { style = "CAUTION", icon = "󰳦", label = "Caution" },
         }
         local qm = qiita_map[note_type] or qiita_map.info
@@ -1936,7 +1930,11 @@ function ContentBuilder:render_document(lines, opts)
         local header_text = indent .. "│ " .. icon .. " " .. qm.label
         self:add_line(header_text, {
           { col = #indent, end_col = #indent + #"│ ", hl = "FloatBorder" },
-          { col = #indent + #"│ ", end_col = #header_text, hl = "MdRenderAlert" .. (qiita_note_type:sub(1, 1) .. qiita_note_type:sub(2):lower()) },
+          {
+            col = #indent + #"│ ",
+            end_col = #header_text,
+            hl = "MdRenderAlert" .. (qiita_note_type:sub(1, 1) .. qiita_note_type:sub(2):lower()),
+          },
         })
         self:apply_alert_styling(lines_before, #self.lines, qiita_note_type, true)
         lines_shown = lines_shown + 1
@@ -1956,11 +1954,10 @@ function ContentBuilder:render_document(lines, opts)
         else
           -- Render as blockquote-style content with alert styling
           local qn_line = "> " .. line
-          local alert_type_ret = self:add_markdown_line(qn_line, indent, max_width, repo_base_url, autolinks, ref_links, footnote_map)
+          local alert_type_ret =
+            self:add_markdown_line(qn_line, indent, max_width, repo_base_url, autolinks, ref_links, footnote_map)
           local lines_after = #self.lines
-          if not alert_type_ret then
-            self:apply_alert_styling(lines_before, lines_after, qiita_note_type, false)
-          end
+          if not alert_type_ret then self:apply_alert_styling(lines_before, lines_after, qiita_note_type, false) end
           lines_shown = lines_shown + (lines_after - lines_before)
           prev_rendered_blank = is_blank
           prev_was_heading = false
@@ -2022,7 +2019,12 @@ function ContentBuilder:render_document(lines, opts)
       else
         -- Mermaid code blocks: render as image if possible
         local mermaid_handled = false
-        if code_block_lang and code_block_lang:lower() == "mermaid" and code_source_lines and #code_source_lines > 0 then
+        if
+          code_block_lang
+          and code_block_lang:lower() == "mermaid"
+          and code_source_lines
+          and #code_source_lines > 0
+        then
           local image = require "md-render.image"
           if image.supports_kitty() and image.has_mmdc() then
             local mermaid_source = table.concat(code_source_lines, "\n")
@@ -2094,9 +2096,7 @@ function ContentBuilder:render_document(lines, opts)
         if not mermaid_handled then
           if code_block_lang and code_block_start < #self.lines then
             local cb_prefix = #indent
-            if in_details and details_summary_rendered then
-              cb_prefix = cb_prefix + #"│ "
-            end
+            if in_details and details_summary_rendered then cb_prefix = cb_prefix + #"│ " end
             table.insert(self.code_blocks, {
               language = code_block_lang,
               start_line = code_block_start,
@@ -2125,14 +2125,12 @@ function ContentBuilder:render_document(lines, opts)
       local display_width = vim.api.nvim_strwidth(indented)
       if not expand_state[code_block_id] and display_width > max_width then
         code_block_has_truncation = true
-        local target = max_width - vim.api.nvim_strwidth("…")
+        local target = max_width - vim.api.nvim_strwidth "…"
         local current_width = 0
         local byte_pos = 0
         for char in indented:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
           local char_width = vim.api.nvim_strwidth(char)
-          if current_width + char_width > target then
-            break
-          end
+          if current_width + char_width > target then break end
           current_width = current_width + char_width
           byte_pos = byte_pos + #char
         end
@@ -2216,14 +2214,12 @@ function ContentBuilder:render_document(lines, opts)
           local display_width = vim.api.nvim_strwidth(code_line)
           if not expand_state[callout_code_block_id] and display_width > max_width then
             callout_code_has_truncation = true
-            local target = max_width - vim.api.nvim_strwidth("…")
+            local target = max_width - vim.api.nvim_strwidth "…"
             local current_width = 0
             local byte_pos = 0
             for char in code_line:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
               local char_width = vim.api.nvim_strwidth(char)
-              if current_width + char_width > target then
-                break
-              end
+              if current_width + char_width > target then break end
               current_width = current_width + char_width
               byte_pos = byte_pos + #char
             end
@@ -2269,8 +2265,7 @@ function ContentBuilder:render_document(lines, opts)
           -- HTML img: <img src="path" alt="alt"> as sole content on line
           -- Also matches inside headings: # <img ...> or ## <img ...>
           if not img_path then
-            local img_tag = line:match "^%s*(<img%s[^>]*>)%s*$"
-              or line:match "^#+%s+(<img%s[^>]*>)%s*$"
+            local img_tag = line:match "^%s*(<img%s[^>]*>)%s*$" or line:match "^#+%s+(<img%s[^>]*>)%s*$"
             if img_tag then
               img_path = img_tag:match 'src="([^"]*)"' or img_tag:match "src='([^']*)'"
               img_alt = img_tag:match 'alt="([^"]*)"' or img_tag:match "alt='([^']*)'"
@@ -2283,12 +2278,9 @@ function ContentBuilder:render_document(lines, opts)
               img_path = video_tag:match 'src="([^"]*)"' or video_tag:match "src='([^']*)'"
               -- If no src on <video>, check for <source src="...">
               if not img_path then
-                img_path = video_tag:match '<source[^>]*src="([^"]*)"'
-                  or video_tag:match "<source[^>]*src='([^']*)'>"
+                img_path = video_tag:match '<source[^>]*src="([^"]*)"' or video_tag:match "<source[^>]*src='([^']*)'>"
               end
-              if img_path then
-                img_alt = img_path:match "([^/]+)$" or img_path
-              end
+              if img_path then img_alt = img_path:match "([^/]+)$" or img_path end
             end
           end
           -- CommonMark autolink to GitHub user-attachments CDN: <https://github.com/user-attachments/assets/...>
@@ -2347,9 +2339,7 @@ function ContentBuilder:render_document(lines, opts)
                     break
                   end
                 end
-                if not is_linked then
-                  table.insert(img_entries, { alt = plain_alt, path = plain_path })
-                end
+                if not is_linked then table.insert(img_entries, { alt = plain_alt, path = plain_path }) end
               end
             end
           end
@@ -2360,9 +2350,7 @@ function ContentBuilder:render_document(lines, opts)
 
           -- Skip badge/shield URLs entirely — they are too small to render
           -- as block images and SVG badges cannot be displayed via Kitty protocol.
-          if image.is_url(img_entry.path) and image.is_badge_url(img_entry.path) then
-            goto continue_img
-          end
+          if image.is_url(img_entry.path) and image.is_badge_url(img_entry.path) then goto continue_img end
 
           local is_video = image.is_video_file(img_entry.path)
 
@@ -2376,12 +2364,8 @@ function ContentBuilder:render_document(lines, opts)
               resolved = image.get_video_cached(src_url)
             else
               local video_path = vim.fn.expand(img_entry.path)
-              if video_path:sub(1, 1) ~= "/" and buf_dir then
-                video_path = buf_dir .. "/" .. video_path
-              end
-              if vim.fn.filereadable(video_path) == 1 then
-                resolved = video_path
-              end
+              if video_path:sub(1, 1) ~= "/" and buf_dir then video_path = buf_dir .. "/" .. video_path end
+              if vim.fn.filereadable(video_path) == 1 then resolved = video_path end
               -- Fallback: try Obsidian vault resolution for local video files
               if not resolved and buf_dir then
                 local obsidian = require "md-render.obsidian"
@@ -2428,12 +2412,14 @@ function ContentBuilder:render_document(lines, opts)
             end
           end
 
-          local display_name = (img_entry.alt and img_entry.alt ~= "") and img_entry.alt or (img_entry.path:match "([^/]+)$" or img_entry.path)
+          local display_name = (img_entry.alt and img_entry.alt ~= "") and img_entry.alt
+            or (img_entry.path:match "([^/]+)$" or img_entry.path)
           if image.supports_kitty() then
             if display_cols and display_rows then
               local raw_icon, icon_hl = icons.get_image_icon(img_entry.path)
               local img_icon = pad_icon(raw_icon)
-              local header_lines_added = self:_emit_image_header(indent, img_icon, icon_hl, display_name, max_width, "Comment")
+              local header_lines_added =
+                self:_emit_image_header(indent, img_icon, icon_hl, display_name, max_width, "Comment")
               local img_start_line = #self.lines
               -- Center the image horizontally
               local img_col = math.max(0, math.floor((max_width - display_cols) / 2))
@@ -2456,8 +2442,11 @@ function ContentBuilder:render_document(lines, opts)
                   -- Center a short message within the image area
                   local pad = math.floor((display_cols - msg_width) / 2)
                   local right_pad = display_cols - pad - msg_width
-                  local placeholder_line = indent .. string.rep(" ", spaces_to_img)
-                      .. string.rep(" ", pad) .. placeholder_msg .. string.rep(" ", right_pad)
+                  local placeholder_line = indent
+                    .. string.rep(" ", spaces_to_img)
+                    .. string.rep(" ", pad)
+                    .. placeholder_msg
+                    .. string.rep(" ", right_pad)
                   local hl_start = #indent + spaces_to_img
                   self:add_line(placeholder_line, {
                     { col = hl_start, end_col = #placeholder_line, hl = "MdRenderImagePlaceholder" },
@@ -2515,13 +2504,12 @@ function ContentBuilder:render_document(lines, opts)
               should_skip = true -- end of document = callout ends
             end
           end
-          if should_skip then
-            handled = true
-          end
+          if should_skip then handled = true end
         end
 
         if not handled then
-          local alert_type, fold_mod = self:add_markdown_line(line, indent, max_width, repo_base_url, autolinks, ref_links, footnote_map)
+          local alert_type, fold_mod =
+            self:add_markdown_line(line, indent, max_width, repo_base_url, autolinks, ref_links, footnote_map)
           local lines_after = #self.lines
           if alert_type then
             current_alert_type = alert_type
@@ -2540,9 +2528,7 @@ function ContentBuilder:render_document(lines, opts)
                 source_line = src_idx,
                 collapsed = is_collapsed,
               })
-              if is_collapsed then
-                skip_callout_body = true
-              end
+              if is_collapsed then skip_callout_body = true end
             end
 
             self:apply_alert_styling(lines_before, #self.lines, current_alert_type, true)
@@ -2558,9 +2544,7 @@ function ContentBuilder:render_document(lines, opts)
     -- Apply │ prefix to lines rendered within <details> body
     if in_details and details_summary_rendered and not skip_details_body then
       local lines_after_render = #self.lines
-      if lines_after_render > lines_before then
-        apply_details_body_prefix(lines_before, lines_after_render)
-      end
+      if lines_after_render > lines_before then apply_details_body_prefix(lines_before, lines_after_render) end
     end
 
     local lines_added = #self.lines - lines_before
@@ -2572,9 +2556,7 @@ function ContentBuilder:render_document(lines, opts)
     if lines_added > 0 then
       prev_was_heading = is_heading
       prev_rendered_blank = is_blank
-      if not is_blank then
-        prev_list_marker_type = markdown.list_marker_type(line)
-      end
+      if not is_blank then prev_list_marker_type = markdown.list_marker_type(line) end
     end
 
     if lines_shown >= max_lines then
@@ -2633,9 +2615,7 @@ function ContentBuilder:render_document(lines, opts)
               hl = hl.hl,
             })
           end
-          if idx == 1 then
-            table.insert(line_hls, { col = #indent, end_col = #prefix, hl = "Special" })
-          end
+          if idx == 1 then table.insert(line_hls, { col = #indent, end_col = #prefix, hl = "Special" }) end
           table.insert(line_hls, { col = 0, end_col = -1, hl = "Comment" })
           self:add_line(line_prefix .. wline, line_hls)
         end

--- a/lua/md-render/display_utils.lua
+++ b/lua/md-render/display_utils.lua
@@ -12,9 +12,7 @@ end
 --- Check if the terminal supports OSC 8 hyperlinks
 ---@return boolean
 function M.supports_osc8()
-  if _osc8_supported ~= nil then
-    return _osc8_supported
-  end
+  if _osc8_supported ~= nil then return _osc8_supported end
 
   local term = vim.env.TERM_PROGRAM
   if term then
@@ -47,9 +45,7 @@ function M.supports_osc8()
   end
 
   -- Fallback: detect via terminal-specific env vars
-  if vim.env.KITTY_WINDOW_ID
-    or vim.env.GHOSTTY_RESOURCES_DIR
-    or vim.env.WEZTERM_EXECUTABLE then
+  if vim.env.KITTY_WINDOW_ID or vim.env.GHOSTTY_RESOURCES_DIR or vim.env.WEZTERM_EXECUTABLE then
     _osc8_supported = true
     return true
   end
@@ -138,17 +134,13 @@ function M.apply_treesitter_highlights(buf, ns, content)
       -- Clamp to actual line lengths to handle truncated lines correctly.
       local start_line_text = content.lines[buf_sr + 1]
       if start_line_text and buf_sc > #start_line_text then
-        if buf_sr == buf_er then
-          goto skip_capture
-        end
+        if buf_sr == buf_er then goto skip_capture end
         buf_sr = buf_sr + 1
         buf_sc = prefix_len
       end
 
       local end_line_text = content.lines[buf_er + 1]
-      if end_line_text and buf_ec > #end_line_text then
-        buf_ec = #end_line_text
-      end
+      if end_line_text and buf_ec > #end_line_text then buf_ec = #end_line_text end
 
       pcall(vim.api.nvim_buf_set_extmark, buf, ns, buf_sr, buf_sc, {
         end_row = buf_er,
@@ -182,16 +174,12 @@ function M.apply_content_to_buffer(buf, ns, content, opts)
     if line_text then
       for _, group in ipairs(hl_info.groups) do
         local end_col = group.end_col
-        if end_col == -1 or end_col > #line_text then
-          end_col = #line_text
-        end
+        if end_col == -1 or end_col > #line_text then end_col = #line_text end
         local extmark_opts = {
           end_col = end_col,
           hl_group = group.hl,
         }
-        if group.hl_eol then
-          extmark_opts.hl_eol = true
-        end
+        if group.hl_eol then extmark_opts.hl_eol = true end
         vim.api.nvim_buf_set_extmark(buf, ns, hl_info.line, group.col, extmark_opts)
       end
     end
@@ -202,12 +190,8 @@ function M.apply_content_to_buffer(buf, ns, content, opts)
     if line_text then
       local col_start = link.col_start
       local col_end = link.col_end
-      if col_start > #line_text then
-        goto next_link
-      end
-      if col_end > #line_text then
-        col_end = #line_text
-      end
+      if col_start > #line_text then goto next_link end
+      if col_end > #line_text then col_end = #line_text end
       local hl
       if link.url:match "^#" then
         hl = "MdRenderLinkAnchor"
@@ -267,12 +251,8 @@ function M.open_float_window(buf, content, float_win, opts)
   local total_height = height + 2
   local max_row = vim.o.lines - vim.o.cmdheight - 1
 
-  if row + total_height > max_row then
-    row = math.max(0, max_row - total_height)
-  end
-  if col + width > vim.o.columns then
-    col = math.max(0, vim.o.columns - width)
-  end
+  if row + total_height > max_row then row = math.max(0, max_row - total_height) end
+  if col + width > vim.o.columns then col = math.max(0, vim.o.columns - width) end
 
   local win = vim.api.nvim_open_win(buf, enter, {
     relative = "editor",
@@ -397,8 +377,13 @@ function M.setup_float_keymaps(buf, ns, win, content, close_handle, opts)
 
       -- Helper: check if click is on an internal anchor or URL extmark
       local function try_open_url()
-        local extmarks =
-          vim.api.nvim_buf_get_extmarks(buf, ns, { click_line, 0 }, { click_line + 1, 0 }, { details = true })
+        local extmarks = vim.api.nvim_buf_get_extmarks(
+          buf,
+          ns,
+          { click_line, 0 },
+          { click_line + 1, 0 },
+          { details = true }
+        )
         for _, mark in ipairs(extmarks) do
           local _, _, start_col, details = unpack(mark)
           if details.url then
@@ -485,9 +470,7 @@ end
 ---@param opts? { buf?: integer, build_content?: fun(): MdRender.Content }
 ---@return MdRender.ImageState?
 function M.setup_images(win, content, ns, opts)
-  if not content.image_placements or #content.image_placements == 0 then
-    return nil
-  end
+  if not content.image_placements or #content.image_placements == 0 then return nil end
 
   local image = require "md-render.image"
   if not image.supports_kitty() then return nil end
@@ -504,7 +487,7 @@ function M.setup_images(win, content, ns, opts)
     placements = content.image_placements,
     image_ids = {},
     anims = {},
-    tx_dims = {},   -- path → {w, h}: actual transmitted image dimensions
+    tx_dims = {}, -- path → {w, h}: actual transmitted image dimensions
     win = win,
     redraw_timer = nil,
     autocmd_ids = {},
@@ -516,9 +499,7 @@ function M.setup_images(win, content, ns, opts)
   local on_download
   if opts and opts.buf and opts.build_content then
     on_download = function()
-      if state._rebuild_timer then
-        state._rebuild_timer:stop()
-      end
+      if state._rebuild_timer then state._rebuild_timer:stop() end
       state._rebuild_timer = vim.defer_fn(function()
         state._rebuild_timer = nil
         if not vim.api.nvim_win_is_valid(win) then return end
@@ -553,11 +534,10 @@ function M.setup_images(win, content, ns, opts)
     local wininfo = vim.fn.getwininfo(state.win)[1]
     if not wininfo then return false end
     local topline = wininfo.topline - 1
-    local win_height = wininfo.height  -- excludes winbar; matches put_image()
+    local win_height = wininfo.height -- excludes winbar; matches put_image()
     local p_start = placement.line or 0
     local p_end = p_start + (placement.rows or 1) - 1
-    return p_end >= topline - LAZY_PADDING
-      and p_start < topline + win_height + LAZY_PADDING
+    return p_end >= topline - LAZY_PADDING and p_start < topline + win_height + LAZY_PADDING
   end
 
   local function place_images()
@@ -570,7 +550,8 @@ function M.setup_images(win, content, ns, opts)
     -- when WinScrolled brings them within range, and skipping them here
     -- prevents bulk transmission of off-screen images.
     for _, placement in ipairs(state.placements) do
-      if placement.path
+      if
+        placement.path
         and not state.image_ids[placement.path]
         and not state.anims[placement.path]
         and not placement._converting
@@ -594,29 +575,45 @@ function M.setup_images(win, content, ns, opts)
       -- Previous frames have no active placement, so clearing them is unnecessary.
       for _, anim in pairs(state.anims) do
         local current_id = anim.frame_ids[anim.current]
-        if current_id then
-          image.clear_placements(current_id)
-        end
+        if current_id then image.clear_placements(current_id) end
       end
       for _, placement in ipairs(state.placements) do
         local anim = state.anims[placement.path]
         if anim then
           local id = anim.frame_ids[anim.current]
           if id then
-            image.put_image(id, state.win, placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
+            image.put_image(
+              id,
+              state.win,
+              placement.line,
+              placement.col,
+              placement.cols,
+              placement.rows,
+              nil,
+              placement.img_w,
+              placement.img_h
+            )
           end
         else
           local id = state.image_ids[placement.path]
           if id then
-            image.put_image(id, state.win, placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
+            image.put_image(
+              id,
+              state.win,
+              placement.line,
+              placement.col,
+              placement.cols,
+              placement.rows,
+              nil,
+              placement.img_w,
+              placement.img_h
+            )
           end
         end
       end
     end)
     image.flush_batch()
-    if not ok then
-      vim.notify("md-render: image redraw error: " .. tostring(err), vim.log.levels.WARN)
-    end
+    if not ok then vim.notify("md-render: image redraw error: " .. tostring(err), vim.log.levels.WARN) end
   end
 
   -- Single shared animation timer for all animated images.
@@ -640,49 +637,69 @@ function M.setup_images(win, content, ns, opts)
       return
     end
     if anim_timer:is_active() then return end
-    anim_timer:start(200, 200, vim.schedule_wrap(function()
-      if not vim.api.nvim_win_is_valid(state.win) then
-        anim_timer:stop()
-        return
-      end
-      -- Clear only animation previous frames, then re-place ALL images.
-      -- - Animation frames must be cleared for the new frame to show
-      --   (WezTerm doesn't visually replace overlapping placements).
-      -- - Static images are NOT cleared but still re-placed every tick
-      --   because WezTerm removes placements when TUI rewrites cells.
-      -- - Clearing must happen BEFORE placing (clear after put causes
-      --   WezTerm to remove the just-placed images too).
-      for _, anim in pairs(state.anims) do
-        if #anim.frame_ids > 1 then
-          local prev_id = anim.frame_ids[anim.current]
-          anim.current = anim.current % #anim.frame_ids + 1
-          if prev_id then
-            image.clear_placements(prev_id)
+    anim_timer:start(
+      200,
+      200,
+      vim.schedule_wrap(function()
+        if not vim.api.nvim_win_is_valid(state.win) then
+          anim_timer:stop()
+          return
+        end
+        -- Clear only animation previous frames, then re-place ALL images.
+        -- - Animation frames must be cleared for the new frame to show
+        --   (WezTerm doesn't visually replace overlapping placements).
+        -- - Static images are NOT cleared but still re-placed every tick
+        --   because WezTerm removes placements when TUI rewrites cells.
+        -- - Clearing must happen BEFORE placing (clear after put causes
+        --   WezTerm to remove the just-placed images too).
+        for _, anim in pairs(state.anims) do
+          if #anim.frame_ids > 1 then
+            local prev_id = anim.frame_ids[anim.current]
+            anim.current = anim.current % #anim.frame_ids + 1
+            if prev_id then image.clear_placements(prev_id) end
           end
         end
-      end
-      image.begin_batch()
-      local ok, err = pcall(function()
-        for _, placement in ipairs(state.placements) do
-          local anim = state.anims[placement.path]
-          if anim then
-            local id = anim.frame_ids[anim.current]
-            if id then
-              image.put_image(id, state.win, placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
-            end
-          else
-            local id = state.image_ids[placement.path]
-            if id then
-              image.put_image(id, state.win, placement.line, placement.col, placement.cols, placement.rows, nil, placement.img_w, placement.img_h)
+        image.begin_batch()
+        local ok, err = pcall(function()
+          for _, placement in ipairs(state.placements) do
+            local anim = state.anims[placement.path]
+            if anim then
+              local id = anim.frame_ids[anim.current]
+              if id then
+                image.put_image(
+                  id,
+                  state.win,
+                  placement.line,
+                  placement.col,
+                  placement.cols,
+                  placement.rows,
+                  nil,
+                  placement.img_w,
+                  placement.img_h
+                )
+              end
+            else
+              local id = state.image_ids[placement.path]
+              if id then
+                image.put_image(
+                  id,
+                  state.win,
+                  placement.line,
+                  placement.col,
+                  placement.cols,
+                  placement.rows,
+                  nil,
+                  placement.img_w,
+                  placement.img_h
+                )
+              end
             end
           end
-        end
+        end)
+        image.flush_batch()
+        if not ok then vim.notify("md-render: animation error: " .. tostring(err), vim.log.levels.WARN) end
       end)
-      image.flush_batch()
-      if not ok then
-        vim.notify("md-render: animation error: " .. tostring(err), vim.log.levels.WARN)
-      end
-    end))
+    )
   end
 
   -- Pause all animation timers (during scroll/redraw to avoid racing with redraw!)
@@ -712,7 +729,7 @@ function M.setup_images(win, content, ns, opts)
       image.end_sync_update()
       resume_anim_timers()
     else
-      vim.cmd("redraw!")
+      vim.cmd "redraw!"
       vim.schedule(function()
         place_images()
         resume_anim_timers()
@@ -721,9 +738,7 @@ function M.setup_images(win, content, ns, opts)
   end
 
   local function schedule_redraw()
-    if state.redraw_timer then
-      state.redraw_timer:stop()
-    end
+    if state.redraw_timer then state.redraw_timer:stop() end
     -- Pause animations immediately on scroll to stop terminal writes
     pause_anim_timers()
     state.redraw_timer = vim.defer_fn(function()
@@ -748,7 +763,7 @@ function M.setup_images(win, content, ns, opts)
     local marks = vim.api.nvim_buf_get_extmarks(buf, ns, { start_line, 0 }, { end_line, -1 }, { details = true })
     for _, mark in ipairs(marks) do
       if mark[4] and mark[4].hl_group == "MdRenderImagePlaceholder" then
-        placeholder_lines[mark[2]] = true  -- mark[2] is the line number
+        placeholder_lines[mark[2]] = true -- mark[2] is the line number
         vim.api.nvim_buf_del_extmark(buf, ns, mark[1])
       end
     end
@@ -857,9 +872,7 @@ function M.setup_images(win, content, ns, opts)
       local placeholder_rows = placement.rows
 
       -- Auto-detect video content when not already flagged (e.g. URL without extension)
-      if not placement.video and image.is_video_content(path) then
-        placement.video = true
-      end
+      if not placement.video and image.is_video_content(path) then placement.video = true end
 
       if placement.video then
         -- Video: always animated, get dimensions via ffprobe
@@ -980,17 +993,17 @@ function M.setup_images(win, content, ns, opts)
       image.begin_batch()
       local ok, err = pcall(process_placement, placement)
       image.flush_batch()
-      if not ok then
-        vim.notify("md-render: image setup error: " .. tostring(err), vim.log.levels.WARN)
-      end
+      if not ok then vim.notify("md-render: image setup error: " .. tostring(err), vim.log.levels.WARN) end
     end
-    vim.schedule(function() process_one(idx + 1) end)
+    vim.schedule(function()
+      process_one(idx + 1)
+    end)
   end
   process_one(1)
 
   -- Re-display on scroll and cursor movement; clean up on window close
   local augroup = vim.api.nvim_create_augroup("md_render_images_" .. win, { clear = true })
-  for _, event in ipairs({ "WinScrolled", "CursorMoved", "CursorMovedI" }) do
+  for _, event in ipairs { "WinScrolled", "CursorMoved", "CursorMovedI" } do
     local id = vim.api.nvim_create_autocmd(event, {
       group = augroup,
       callback = function(ev)
@@ -1028,9 +1041,7 @@ end
 ---@return MdRender.ImageState?
 function M.update_images(state, win, content)
   -- No previous state: full setup from scratch
-  if not state then
-    return M.setup_images(win, content, nil)
-  end
+  if not state then return M.setup_images(win, content, nil) end
 
   -- No images in new content: full cleanup
   if not content.image_placements or #content.image_placements == 0 then
@@ -1117,9 +1128,7 @@ function M.cleanup_images(state)
   state.canceled = true
 
   -- Stop download-rebuild timer
-  if state._rebuild_timer then
-    state._rebuild_timer:stop()
-  end
+  if state._rebuild_timer then state._rebuild_timer:stop() end
 
   -- Delete static images from terminal
   local ids = {}
@@ -1136,9 +1145,7 @@ function M.cleanup_images(state)
     for _, fid in ipairs(anim.frame_ids) do
       table.insert(ids, fid)
     end
-    if anim.tmp_dir then
-      vim.fn.delete(anim.tmp_dir, "rf")
-    end
+    if anim.tmp_dir then vim.fn.delete(anim.tmp_dir, "rf") end
   end
 
   image.delete_images(ids)
@@ -1146,9 +1153,7 @@ function M.cleanup_images(state)
   image.delete_all()
 
   -- Stop redraw timer
-  if state.redraw_timer then
-    state.redraw_timer:stop()
-  end
+  if state.redraw_timer then state.redraw_timer:stop() end
 
   -- Remove autocmds
   pcall(vim.api.nvim_del_augroup_by_name, "md_render_images_" .. state.win)

--- a/lua/md-render/float_win.lua
+++ b/lua/md-render/float_win.lua
@@ -11,15 +11,11 @@ end
 function FloatWin:setup(win, opts)
   self.win = win
   opts = opts or {}
-  if opts.auto_close == false then
-    return
-  end
+  if opts.auto_close == false then return end
   vim.api.nvim_create_autocmd({ "WinEnter", "CursorMoved" }, {
     group = vim.api.nvim_create_augroup(self.augroup, { clear = false }),
     callback = function()
-      if self.win ~= vim.api.nvim_get_current_win() then
-        self:close_if_valid()
-      end
+      if self.win ~= vim.api.nvim_get_current_win() then self:close_if_valid() end
     end,
   })
   vim.api.nvim_create_autocmd("WinClosed", {

--- a/lua/md-render/icons.lua
+++ b/lua/md-render/icons.lua
@@ -109,9 +109,7 @@ local DEFAULT_IMAGE_ICON = "󰋩"
 ---@param icon string single icon character
 ---@return string
 function M.pad_icon(icon)
-  if vim.api.nvim_strwidth(icon) == 1 then
-    return icon .. " "
-  end
+  if vim.api.nvim_strwidth(icon) == 1 then return icon .. " " end
   return icon
 end
 
@@ -125,34 +123,26 @@ function M.get_file_icon(filename)
   local ok, devicons = pcall(require, "nvim-web-devicons")
   if ok then
     local icon, hl = devicons.get_icon(filename, nil, { default = false })
-    if icon then
-      return icon, hl
-    end
+    if icon then return icon, hl end
   end
 
   -- Try mini.icons
   local ok2, mini_icons = pcall(require, "mini.icons")
   if ok2 then
     local ok3, icon, hl = pcall(mini_icons.get, "file", filename)
-    if ok3 and icon then
-      return icon, hl
-    end
+    if ok3 and icon then return icon, hl end
   end
 
   -- Built-in fallback: check special filenames first
-  local base = filename:match("[^/]+$") or filename
+  local base = filename:match "[^/]+$" or filename
   local base_lower = base:lower()
-  if file_name_icons[base_lower] then
-    return file_name_icons[base_lower], nil
-  end
+  if file_name_icons[base_lower] then return file_name_icons[base_lower], nil end
 
   -- Then check extension
-  local ext = base:match("%.([^.]+)$")
+  local ext = base:match "%.([^.]+)$"
   if ext then
     local icon = file_ext_icons[ext:lower()]
-    if icon then
-      return icon, nil
-    end
+    if icon then return icon, nil end
   end
 
   -- Default file icon
@@ -168,12 +158,10 @@ end
 function M.get_image_icon(path)
   -- Extract basename from path or URL (strip query string / fragment)
   local clean = path:gsub("[?#].*$", "")
-  local base = clean:match("([^/]+)$") or clean
+  local base = clean:match "([^/]+)$" or clean
   if base ~= "" then
     local icon, hl = M.get_file_icon(base)
-    if icon ~= "" then
-      return icon, hl
-    end
+    if icon ~= "" then return icon, hl end
   end
   return DEFAULT_IMAGE_ICON, nil
 end

--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -14,8 +14,8 @@
 local M = {}
 
 local uv = vim.uv or vim.loop
-local ffi = require("ffi")
-local tty_mod = require("md-render.tty")
+local ffi = require "ffi"
+local tty_mod = require "md-render.tty"
 
 local IS_WINDOWS = ffi.os == "Windows"
 
@@ -60,14 +60,10 @@ function M.flush_batch()
   -- Pop parent batch if nested
   if _batch_stack and #_batch_stack > 0 then
     _batch_buffer = table.remove(_batch_stack)
-    if data ~= "" then
-      table.insert(_batch_buffer, data)
-    end
+    if data ~= "" then table.insert(_batch_buffer, data) end
   else
     _batch_buffer = nil
-    if data ~= "" then
-      term_write(data)
-    end
+    if data ~= "" then term_write(data) end
   end
 end
 
@@ -79,12 +75,12 @@ end
 --- and renders it atomically when end_sync_update() is called.
 --- Supported by WezTerm, Kitty, foot, and others.
 function M.begin_sync_update()
-  term_write("\x1b[?2026h")
+  term_write "\x1b[?2026h"
 end
 
 --- End synchronized update and flush buffered output to screen.
 function M.end_sync_update()
-  term_write("\x1b[?2026l")
+  term_write "\x1b[?2026l"
 end
 
 -- ============================================================================
@@ -97,22 +93,22 @@ local function ensure_ffi()
   _ffi_declared = true
   -- ioctl/winsize are POSIX-only; Windows has no equivalent in MSVCRT.
   if IS_WINDOWS then return end
-  ffi.cdef([[
+  ffi.cdef [[
     typedef struct { unsigned short row; unsigned short col; unsigned short xpixel; unsigned short ypixel; } winsize;
     int ioctl(int, unsigned long, ...);
     int open(const char *path, int flags);
     int close(int fd);
-  ]])
+  ]]
 end
 
-local TIOCGWINSZ = (vim.fn.has("mac") == 1 or vim.fn.has("bsd") == 1) and 0x40087468 or 0x5413
+local TIOCGWINSZ = (vim.fn.has "mac" == 1 or vim.fn.has "bsd" == 1) and 0x40087468 or 0x5413
 
 ---@return { cell_w: number, cell_h: number }?
 function M.get_cell_size()
   if M._test_cell_size then return M._test_cell_size end
   if IS_WINDOWS then return nil end
   ensure_ffi()
-  local sz = ffi.new("winsize")
+  local sz = ffi.new "winsize"
   -- Try stdout (fd 1) first; after :restart it may be /dev/null,
   -- so fall back to opening the discovered TTY device.
   if ffi.C.ioctl(1, TIOCGWINSZ, sz) ~= 0 then
@@ -144,13 +140,18 @@ local function read_header(path, n)
   return data
 end
 
-local function be16(s, o) return s:byte(o) * 256 + s:byte(o + 1) end
-local function be32(s, o)
-  return s:byte(o) * 16777216 + s:byte(o + 1) * 65536
-       + s:byte(o + 2) * 256 + s:byte(o + 3)
+local function be16(s, o)
+  return s:byte(o) * 256 + s:byte(o + 1)
 end
-local function le16(s, o) return s:byte(o) + s:byte(o + 1) * 256 end
-local function le24(s, o) return s:byte(o) + s:byte(o + 1) * 256 + s:byte(o + 2) * 65536 end
+local function be32(s, o)
+  return s:byte(o) * 16777216 + s:byte(o + 1) * 65536 + s:byte(o + 2) * 256 + s:byte(o + 3)
+end
+local function le16(s, o)
+  return s:byte(o) + s:byte(o + 1) * 256
+end
+local function le24(s, o)
+  return s:byte(o) + s:byte(o + 1) * 256 + s:byte(o + 2) * 65536
+end
 
 local function png_dimensions(path)
   local h = read_header(path, 24)
@@ -161,17 +162,18 @@ end
 local function jpeg_dimensions(path)
   local f = io.open(path, "rb")
   if not f then return nil end
-  local data = f:read("*a")
+  local data = f:read "*a"
   f:close()
   if not data or #data < 2 or data:byte(1) ~= 0xFF or data:byte(2) ~= 0xD8 then return nil end
   local pos = 3
   while pos < #data - 1 do
-    if data:byte(pos) ~= 0xFF then pos = pos + 1; goto continue end
+    if data:byte(pos) ~= 0xFF then
+      pos = pos + 1
+      goto continue
+    end
     local marker = data:byte(pos + 1)
     if marker >= 0xC0 and marker <= 0xCF and marker ~= 0xC4 and marker ~= 0xC8 then
-      if pos + 9 <= #data then
-        return be16(data, pos + 7), be16(data, pos + 5)
-      end
+      if pos + 9 <= #data then return be16(data, pos + 7), be16(data, pos + 5) end
     end
     if pos + 3 <= #data then
       pos = pos + 2 + be16(data, pos + 2)
@@ -234,14 +236,19 @@ end
 
 --- Video file extensions supported for frame extraction
 local VIDEO_EXTENSIONS = {
-  mp4 = true, webm = true, mov = true, avi = true, mkv = true, m4v = true,
+  mp4 = true,
+  webm = true,
+  mov = true,
+  avi = true,
+  mkv = true,
+  m4v = true,
 }
 
 --- Check if a file path points to a video file (by extension).
 ---@param path string
 ---@return boolean
 function M.is_video_file(path)
-  local ext = path:match("%.(%w+)$")
+  local ext = path:match "%.(%w+)$"
   if not ext then return false end
   return VIDEO_EXTENSIONS[ext:lower()] == true
 end
@@ -268,18 +275,23 @@ end
 ---@param path string absolute path to video file
 ---@return integer? width, integer? height
 function M.video_dimensions(path)
-  if vim.fn.executable("ffprobe") ~= 1 then return nil, nil end
-  local result = vim.system(
-    {
-      "ffprobe", "-v", "error",
-      "-select_streams", "v:0",
-      "-show_entries", "stream=width,height",
-      "-of", "csv=p=0:s=x", path,
-    },
-    { text = true, timeout = 5000 }
-  ):wait()
+  if vim.fn.executable "ffprobe" ~= 1 then return nil, nil end
+  local result = vim
+    .system({
+      "ffprobe",
+      "-v",
+      "error",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=width,height",
+      "-of",
+      "csv=p=0:s=x",
+      path,
+    }, { text = true, timeout = 5000 })
+    :wait()
   if result.code == 0 and result.stdout then
-    local w, h = result.stdout:match("(%d+)x(%d+)")
+    local w, h = result.stdout:match "(%d+)x(%d+)"
     if w and h then return tonumber(w), tonumber(h) end
   end
   return nil, nil
@@ -291,27 +303,29 @@ end
 ---@param callback fun(width: integer?, height: integer?)
 function M.video_dimensions_async(path, callback)
   -- Use ffprobe to get original video dimensions
-  vim.system(
-    {
-      "ffprobe", "-v", "error",
-      "-select_streams", "v:0",
-      "-show_entries", "stream=width,height",
-      "-of", "csv=p=0:s=x", path,
-    },
-    { text = true, timeout = 10000 },
-    function(result)
-      vim.schedule(function()
-        if result.code == 0 and result.stdout then
-          local w, h = result.stdout:match("(%d+)x(%d+)")
-          if w and h then
-            callback(tonumber(w), tonumber(h))
-            return
-          end
+  vim.system({
+    "ffprobe",
+    "-v",
+    "error",
+    "-select_streams",
+    "v:0",
+    "-show_entries",
+    "stream=width,height",
+    "-of",
+    "csv=p=0:s=x",
+    path,
+  }, { text = true, timeout = 10000 }, function(result)
+    vim.schedule(function()
+      if result.code == 0 and result.stdout then
+        local w, h = result.stdout:match "(%d+)x(%d+)"
+        if w and h then
+          callback(tonumber(w), tonumber(h))
+          return
         end
-        callback(nil, nil)
-      end)
-    end
-  )
+      end
+      callback(nil, nil)
+    end)
+  end)
 end
 
 ---@param path string
@@ -333,7 +347,7 @@ end
 --- Get cache directory for rendered mermaid diagrams
 ---@return string
 local function get_mermaid_cache_dir()
-  local dir = vim.fn.stdpath("cache") .. "/md-render/mermaid"
+  local dir = vim.fn.stdpath "cache" .. "/md-render/mermaid"
   vim.fn.mkdir(dir, "p")
   return dir
 end
@@ -347,9 +361,9 @@ local _mmdc_checked = false
 local function find_mmdc()
   if _mmdc_checked then return _mmdc_cmd end
   _mmdc_checked = true
-  if vim.fn.executable("mmdc") == 1 then
+  if vim.fn.executable "mmdc" == 1 then
     _mmdc_cmd = { "mmdc" }
-  elseif vim.fn.executable("npx") == 1 then
+  elseif vim.fn.executable "npx" == 1 then
     _mmdc_cmd = { "npx", "-y", "@mermaid-js/mermaid-cli" }
   end
   return _mmdc_cmd
@@ -365,11 +379,9 @@ end
 --- the appropriate mermaid theme name and background color hex string.
 ---@return string theme, string bg_hex
 local function mermaid_theme_args()
-  local bg = vim.o.background  -- "dark" or "light"
+  local bg = vim.o.background -- "dark" or "light"
   local hl = vim.api.nvim_get_hl(0, { name = "NormalFloat", link = false })
-  if not hl.bg then
-    hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
-  end
+  if not hl.bg then hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false }) end
   local bg_color = hl.bg
   if bg == "dark" then
     local hex = bg_color and string.format("#%06x", bg_color) or "#1e1e2e"
@@ -398,8 +410,16 @@ local function build_mmdc_cmd(cmd_prefix, input_path, output_path)
   local theme, bg_hex = mermaid_theme_args()
   local cmd = vim.list_extend({}, cmd_prefix)
   vim.list_extend(cmd, {
-    "-i", input_path, "-o", output_path,
-    "-t", theme, "-b", bg_hex, "-s", "2",
+    "-i",
+    input_path,
+    "-o",
+    output_path,
+    "-t",
+    theme,
+    "-b",
+    bg_hex,
+    "-s",
+    "2",
   })
   return cmd
 end
@@ -409,9 +429,7 @@ end
 ---@return string? cached_path
 function M.get_mermaid_cached(source)
   local cache_path = mermaid_cache_path(source)
-  if vim.fn.filereadable(cache_path) == 1 then
-    return cache_path
-  end
+  if vim.fn.filereadable(cache_path) == 1 then return cache_path end
   return nil
 end
 
@@ -423,9 +441,7 @@ function M.render_mermaid(source)
   if not cmd_prefix then return nil end
 
   local cache_path = mermaid_cache_path(source)
-  if vim.fn.filereadable(cache_path) == 1 then
-    return cache_path
-  end
+  if vim.fn.filereadable(cache_path) == 1 then return cache_path end
 
   local tmp_input = vim.fn.tempname() .. ".mmd"
   local f = io.open(tmp_input, "w")
@@ -437,9 +453,7 @@ function M.render_mermaid(source)
   local result = vim.system(cmd, { text = true, timeout = 30000 }):wait()
   os.remove(tmp_input)
 
-  if vim.fn.filereadable(cache_path) == 1 then
-    return cache_path
-  end
+  if vim.fn.filereadable(cache_path) == 1 then return cache_path end
   return nil
 end
 
@@ -516,9 +530,7 @@ end
 ---@return true?
 local function probe_kitty_via_apc()
   local ok, tty = pcall(require, "vim.tty")
-  if not ok or type(tty) ~= "table" or type(tty.query_apc) ~= "function" then
-    return nil
-  end
+  if not ok or type(tty) ~= "table" or type(tty.query_apc) ~= "function" then return nil end
   -- Some terminals (notably Apple Terminal) echo unknown APC payloads back
   -- into the buffer; skip the probe outright there.
   if vim.env.TERM_PROGRAM == "Apple_Terminal" then return nil end
@@ -532,7 +544,9 @@ local function probe_kitty_via_apc()
       return true
     end
   end)
-  vim.wait(250, function() return supported ~= nil end, 20)
+  vim.wait(250, function()
+    return supported ~= nil
+  end, 20)
   return supported
 end
 
@@ -626,7 +640,7 @@ end
 ---@param s string
 ---@return boolean
 function M.is_url(s)
-  return s:match("^https?://") ~= nil
+  return s:match "^https?://" ~= nil
 end
 
 --- URLs that are badges or tiny icons — not worth displaying as block images
@@ -665,7 +679,7 @@ local _url_cache = {}
 --- Get cache directory for downloaded images
 ---@return string
 local function get_cache_dir()
-  local dir = vim.fn.stdpath("cache") .. "/md-render/images"
+  local dir = vim.fn.stdpath "cache" .. "/md-render/images"
   vim.fn.mkdir(dir, "p")
   return dir
 end
@@ -676,9 +690,9 @@ end
 local function url_to_cache_path(url)
   -- Use a hash of the URL as filename, preserve extension
   local hash = vim.fn.sha256(url):sub(1, 16)
-  local ext = url:match("%.(%w+)$") or "png"
+  local ext = url:match "%.(%w+)$" or "png"
   -- Clean extension (remove query params)
-  ext = ext:match("^(%w+)") or "png"
+  ext = ext:match "^(%w+)" or "png"
   return get_cache_dir() .. "/" .. hash .. "." .. ext
 end
 
@@ -688,9 +702,7 @@ end
 function M.get_cached(url)
   if _url_cache[url] and vim.fn.filereadable(_url_cache[url]) == 1 then
     -- Validate cached file is a recognized image or video format
-    if M.image_dimensions(_url_cache[url]) or M.is_video_content(_url_cache[url]) then
-      return _url_cache[url]
-    end
+    if M.image_dimensions(_url_cache[url]) or M.is_video_content(_url_cache[url]) then return _url_cache[url] end
     -- Stale/corrupt cache entry: remove file and clear in-memory cache
     os.remove(_url_cache[url])
     _url_cache[url] = nil
@@ -708,9 +720,9 @@ function M.get_cached(url)
     return nil
   end
   -- Try video extensions (file may have been renamed by finalize_download)
-  local hash = cache_path:match("/([^/]+)%.[^.]+$")
+  local hash = cache_path:match "/([^/]+)%.[^.]+$"
   if hash then
-    for _, ext in ipairs({ "mp4", "webm", "avi" }) do
+    for _, ext in ipairs { "mp4", "webm", "avi" } do
       local alt_path = get_cache_dir() .. "/" .. hash .. "." .. ext
       if vim.fn.filereadable(alt_path) == 1 and M.is_video_content(alt_path) then
         _url_cache[url] = alt_path
@@ -748,7 +760,7 @@ local function finalize_download(url, cache_path, callback)
     -- Check if it's a video with wrong extension
     local video_ext = detect_video_ext(cache_path)
     if video_ext then
-      local current_ext = cache_path:match("%.(%w+)$")
+      local current_ext = cache_path:match "%.(%w+)$"
       if current_ext and current_ext ~= video_ext then
         local correct_path = cache_path:gsub("%." .. current_ext .. "$", "." .. video_ext)
         os.rename(cache_path, correct_path)
@@ -816,9 +828,7 @@ end
 ---@param url string
 ---@return string? cached_path
 function M.get_video_cached(url)
-  if _url_cache[url] and vim.fn.filereadable(_url_cache[url]) == 1 then
-    return _url_cache[url]
-  end
+  if _url_cache[url] and vim.fn.filereadable(_url_cache[url]) == 1 then return _url_cache[url] end
   local cache_path = url_to_cache_path(url)
   if vim.fn.filereadable(cache_path) == 1 then
     _url_cache[url] = cache_path
@@ -887,21 +897,15 @@ function M.resolve(src, base_dir)
   end
 
   local resolved = vim.fn.expand(src)
-  if resolved:sub(1, 1) ~= "/" and base_dir then
-    resolved = base_dir .. "/" .. resolved
-  end
+  if resolved:sub(1, 1) ~= "/" and base_dir then resolved = base_dir .. "/" .. resolved end
 
-  if vim.fn.filereadable(resolved) == 1 then
-    return resolved
-  end
+  if vim.fn.filereadable(resolved) == 1 then return resolved end
 
   -- Fallback: try Obsidian vault resolution
   if base_dir then
     local obsidian = require "md-render.obsidian"
     local vault_resolved = obsidian.resolve(src, base_dir)
-    if vault_resolved then
-      return vault_resolved
-    end
+    if vault_resolved then return vault_resolved end
   end
 
   return nil
@@ -920,11 +924,11 @@ local _convert_checked = false
 local function find_convert_tool()
   if _convert_checked then return _convert_cmd end
   _convert_checked = true
-  if vim.fn.has("mac") == 1 and vim.fn.executable("sips") == 1 then
+  if vim.fn.has "mac" == 1 and vim.fn.executable "sips" == 1 then
     _convert_cmd = "sips"
-  elseif vim.fn.executable("ffmpeg") == 1 then
+  elseif vim.fn.executable "ffmpeg" == 1 then
     _convert_cmd = "ffmpeg"
-  elseif vim.fn.executable("magick") == 1 then
+  elseif vim.fn.executable "magick" == 1 then
     _convert_cmd = "magick"
   end
   return _convert_cmd
@@ -939,9 +943,9 @@ local _anim_checked = false
 local function find_anim_tool()
   if _anim_checked then return _anim_cmd end
   _anim_checked = true
-  if vim.fn.executable("ffmpeg") == 1 then
+  if vim.fn.executable "ffmpeg" == 1 then
     _anim_cmd = "ffmpeg"
-  elseif vim.fn.executable("magick") == 1 then
+  elseif vim.fn.executable "magick" == 1 then
     _anim_cmd = "magick"
   end
   return _anim_cmd
@@ -965,9 +969,14 @@ local function build_convert_cmd(tool, src, dst)
     -- scale filter with force_original_aspect_ratio keeps aspect ratio;
     -- -vframes 1 ensures only one frame for static images
     return {
-      "ffmpeg", "-y", "-i", src,
-      "-vframes", "1",
-      "-vf", "scale='min(" .. dim .. ",iw)':'min(" .. dim .. ",ih)':force_original_aspect_ratio=decrease",
+      "ffmpeg",
+      "-y",
+      "-i",
+      src,
+      "-vframes",
+      "1",
+      "-vf",
+      "scale='min(" .. dim .. ",iw)':'min(" .. dim .. ",ih)':force_original_aspect_ratio=decrease",
       dst,
     }
   else
@@ -982,7 +991,7 @@ end
 --- Get cache directory for converted PNGs (JPEG/WebP → PNG).
 ---@return string
 local function get_converted_cache_dir()
-  local dir = vim.fn.stdpath("cache") .. "/md-render/converted"
+  local dir = vim.fn.stdpath "cache" .. "/md-render/converted"
   vim.fn.mkdir(dir, "p")
   return dir
 end
@@ -996,10 +1005,7 @@ local function get_converted_cache_path(src_path)
   local mtime = vim.fn.getftime(src_path)
   if mtime < 0 then return nil end
   local hash = vim.fn.sha256(src_path):sub(1, 16)
-  return string.format(
-    "%s/%s_%d_%d.png",
-    get_converted_cache_dir(), hash, mtime, MAX_CONVERT_DIM
-  )
+  return string.format("%s/%s_%d_%d.png", get_converted_cache_dir(), hash, mtime, MAX_CONVERT_DIM)
 end
 
 --- Atomically install a freshly converted PNG into the cache.
@@ -1018,7 +1024,7 @@ local function install_to_cache(tmp, cache_path)
     local data
     local f = io.open(tmp, "rb")
     if f then
-      data = f:read("*a")
+      data = f:read "*a"
       f:close()
     end
     if not data then return false end
@@ -1041,15 +1047,11 @@ function M.ensure_png(path)
   local tool = find_convert_tool()
   if not tool then return nil, false end
   local cache_path = get_converted_cache_path(path)
-  if cache_path and vim.fn.filereadable(cache_path) == 1 then
-    return cache_path, false
-  end
+  if cache_path and vim.fn.filereadable(cache_path) == 1 then return cache_path, false end
   local tmp = vim.fn.tempname() .. ".png"
   local result = vim.system(build_convert_cmd(tool, path, tmp), { text = true }):wait()
   if result.code ~= 0 then return nil, false end
-  if cache_path and install_to_cache(tmp, cache_path) then
-    return cache_path, false
-  end
+  if cache_path and install_to_cache(tmp, cache_path) then return cache_path, false end
   return tmp, true
 end
 
@@ -1072,23 +1074,19 @@ function M.ensure_png_async(path, callback)
     return
   end
   local tmp = vim.fn.tempname() .. ".png"
-  vim.system(
-    build_convert_cmd(tool, path, tmp),
-    { text = true },
-    function(result)
-      vim.schedule(function()
-        if result.code ~= 0 then
-          callback(nil, false)
-          return
-        end
-        if cache_path and install_to_cache(tmp, cache_path) then
-          callback(cache_path, false)
-        else
-          callback(tmp, true)
-        end
-      end)
-    end
-  )
+  vim.system(build_convert_cmd(tool, path, tmp), { text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        callback(nil, false)
+        return
+      end
+      if cache_path and install_to_cache(tmp, cache_path) then
+        callback(cache_path, false)
+      else
+        callback(tmp, true)
+      end
+    end)
+  end)
 end
 
 --- Choose the rounding direction (floor vs ceil) for the dependent dimension
@@ -1115,9 +1113,7 @@ local function best_round(fixed_cells, fixed_cell_px, dep_px, dep_cell_px, dep_m
     fl_ratio = (r_floor * dep_cell_px) / (fixed_cells * fixed_cell_px)
     cl_ratio = (r_ceil * dep_cell_px) / (fixed_cells * fixed_cell_px)
   end
-  if math.abs(fl_ratio - target) <= math.abs(cl_ratio - target) then
-    return r_floor
-  end
+  if math.abs(fl_ratio - target) <= math.abs(cl_ratio - target) then return r_floor end
   return r_ceil
 end
 
@@ -1161,8 +1157,8 @@ end
 -- ============================================================================
 
 local _image_id = 100
-local _image_paths = {}  -- image_id → file path (for Ghostty a=T workaround)
-local _temp_image_paths = {}  -- image_id → true for temp files that need cleanup
+local _image_paths = {} -- image_id → file path (for Ghostty a=T workaround)
+local _temp_image_paths = {} -- image_id → true for temp files that need cleanup
 local _session_cleared = false
 
 --- Transmit image data to terminal (store without displaying).
@@ -1183,10 +1179,7 @@ function M.transmit_image(path)
   local t = (is_temp and not is_ghostty()) and "t" or "f"
 
   -- a=t: transmit and store, q=2: suppress all responses
-  local message = string.format(
-    "\x1b_Ga=t,f=100,t=%s,i=%d,q=2;%s\x1b\\",
-    t, id, b64_path
-  )
+  local message = string.format("\x1b_Ga=t,f=100,t=%s,i=%d,q=2;%s\x1b\\", t, id, b64_path)
   term_write(message)
 
   if is_temp and is_ghostty() then
@@ -1199,7 +1192,7 @@ function M.transmit_image(path)
   return id
 end
 
-local MAX_ANIM_FRAMES = 300  -- max frames to extract (= 60 seconds at 5 fps)
+local MAX_ANIM_FRAMES = 300 -- max frames to extract (= 60 seconds at 5 fps)
 
 --- Build a command to count frames in an animated GIF.
 ---@param tool string  "ffmpeg" or "magick"
@@ -1208,10 +1201,17 @@ local MAX_ANIM_FRAMES = 300  -- max frames to extract (= 60 seconds at 5 fps)
 local function build_frame_count_cmd(tool, path)
   if tool == "ffmpeg" then
     return {
-      "ffprobe", "-v", "error",
-      "-count_frames", "-select_streams", "v:0",
-      "-show_entries", "stream=nb_read_frames",
-      "-of", "csv=p=0", path,
+      "ffprobe",
+      "-v",
+      "error",
+      "-count_frames",
+      "-select_streams",
+      "v:0",
+      "-show_entries",
+      "stream=nb_read_frames",
+      "-of",
+      "csv=p=0",
+      path,
     }
   else
     return { "magick", "identify", "-format", "%n\n", path }
@@ -1231,10 +1231,16 @@ local function build_frame_extract_cmd(tool, path, cache_dir, total_frames)
     table.insert(vf_parts, "fps=5")
     table.insert(vf_parts, "scale='min(400,iw)':'min(400,ih)':force_original_aspect_ratio=decrease")
     return {
-      "ffmpeg", "-y", "-i", path,
-      "-vf", table.concat(vf_parts, ","),
-      "-frames:v", tostring(MAX_ANIM_FRAMES),
-      "-vsync", "vfr",
+      "ffmpeg",
+      "-y",
+      "-i",
+      path,
+      "-vf",
+      table.concat(vf_parts, ","),
+      "-frames:v",
+      tostring(MAX_ANIM_FRAMES),
+      "-vsync",
+      "vfr",
       cache_dir .. "/frame_%04d.png",
     }
   else
@@ -1243,9 +1249,7 @@ local function build_frame_extract_cmd(tool, path, cache_dir, total_frames)
       local step = math.ceil(total_frames / MAX_ANIM_FRAMES)
       local delete = {}
       for i = 0, total_frames - 1 do
-        if i % step ~= 0 then
-          table.insert(delete, tostring(i))
-        end
+        if i % step ~= 0 then table.insert(delete, tostring(i)) end
       end
       if #delete > 0 then
         table.insert(cmd, "-delete")
@@ -1280,13 +1284,10 @@ function M.transmit_animated(path)
   local cached = get_cached_frames(path, cache_dir)
   if not cached then
     -- Count total frames first
-    local count_result = vim.system(
-      build_frame_count_cmd(anim_tool, path),
-      { text = true }
-    ):wait()
+    local count_result = vim.system(build_frame_count_cmd(anim_tool, path), { text = true }):wait()
     local total_frames = 1
     if count_result.code == 0 and count_result.stdout then
-      total_frames = tonumber(count_result.stdout:match("%d+")) or 1
+      total_frames = tonumber(count_result.stdout:match "%d+") or 1
     end
 
     vim.fn.mkdir(cache_dir, "p")
@@ -1315,10 +1316,7 @@ function M.transmit_animated(path)
     _image_id = _image_id + 1
     local id = _image_id
     local b64_path = vim.base64.encode(frame_path)
-    term_write(string.format(
-      "\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\",
-      id, b64_path
-    ))
+    term_write(string.format("\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\", id, b64_path))
     _image_paths[id] = frame_path
     table.insert(frame_ids, id)
   end
@@ -1348,13 +1346,8 @@ function M.transmit_image_async(path, callback)
     local b64_path = vim.base64.encode(png_path)
     -- Ghostty does not support t=t; always use t=f and delete temp files ourselves
     local t = (is_temp and not is_ghostty()) and "t" or "f"
-    term_write(string.format(
-      "\x1b_Ga=t,f=100,t=%s,i=%d,q=2;%s\x1b\\",
-      t, id, b64_path
-    ))
-    if is_temp and is_ghostty() then
-      _temp_image_paths[id] = true
-    end
+    term_write(string.format("\x1b_Ga=t,f=100,t=%s,i=%d,q=2;%s\x1b\\", t, id, b64_path))
+    if is_temp and is_ghostty() then _temp_image_paths[id] = true end
     _image_paths[id] = png_path
     -- Return actual transmitted dimensions when the converted PNG differs from
     -- the source (conversion may have resized, e.g. large JPEG → 2000px PNG).
@@ -1439,17 +1432,12 @@ function M.transmit_animated_async(path, callback)
       M.begin_batch()
       for i = idx, end_idx do
         local b64_path = vim.base64.encode(frames[i])
-        term_write(string.format(
-          "\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\",
-          all_ids[i], b64_path
-        ))
+        term_write(string.format("\x1b_Ga=t,f=100,t=f,i=%d,q=2;%s\x1b\\", all_ids[i], b64_path))
         _image_paths[all_ids[i]] = frames[i]
       end
       M.flush_batch()
       idx = end_idx + 1
-      if idx <= total then
-        vim.defer_fn(send_next_batch, 10)
-      end
+      if idx <= total then vim.defer_fn(send_next_batch, 10) end
     end
 
     send_next_batch()
@@ -1464,42 +1452,38 @@ function M.transmit_animated_async(path, callback)
   end
 
   -- Count frames first
-  vim.system(
-    build_frame_count_cmd(anim_tool, path),
-    { text = true },
-    function(count_result)
-      vim.schedule(function()
-        local total_frames = 1
-        if count_result.code == 0 and count_result.stdout then
-          total_frames = tonumber(count_result.stdout:match("%d+")) or 1
-        end
+  vim.system(build_frame_count_cmd(anim_tool, path), { text = true }, function(count_result)
+    vim.schedule(function()
+      local total_frames = 1
+      if count_result.code == 0 and count_result.stdout then
+        total_frames = tonumber(count_result.stdout:match "%d+") or 1
+      end
 
-        vim.fn.mkdir(cache_dir, "p")
+      vim.fn.mkdir(cache_dir, "p")
 
-        local cmd = build_frame_extract_cmd(anim_tool, path, cache_dir, total_frames)
+      local cmd = build_frame_extract_cmd(anim_tool, path, cache_dir, total_frames)
 
-        vim.system(cmd, { text = true, timeout = 30000 }, function(result)
-          vim.schedule(function()
-            if result.code ~= 0 then
-              vim.fn.delete(cache_dir, "rf")
-              callback(nil)
-              return
-            end
+      vim.system(cmd, { text = true, timeout = 30000 }, function(result)
+        vim.schedule(function()
+          if result.code ~= 0 then
+            vim.fn.delete(cache_dir, "rf")
+            callback(nil)
+            return
+          end
 
-            local frames = vim.fn.glob(cache_dir .. "/frame_*.png", false, true)
-            table.sort(frames)
-            if #frames == 0 then
-              vim.fn.delete(cache_dir, "rf")
-              callback(nil)
-              return
-            end
+          local frames = vim.fn.glob(cache_dir .. "/frame_*.png", false, true)
+          table.sort(frames)
+          if #frames == 0 then
+            vim.fn.delete(cache_dir, "rf")
+            callback(nil)
+            return
+          end
 
-            transmit_frames(frames)
-          end)
+          transmit_frames(frames)
         end)
       end)
-    end
-  )
+    end)
+  end)
 end
 
 --- Display an image at a screen position.
@@ -1527,7 +1511,7 @@ function M.put_image(image_id, win, row, col, display_cols, display_rows, anim_p
   -- spill `winbar_height` rows into the statusline.
   local wininfo = vim.fn.getwininfo(win)[1]
   local win_height = wininfo.height
-  local topline = wininfo.topline - 1  -- 0-indexed
+  local topline = wininfo.topline - 1 -- 0-indexed
   local leftcol = wininfo.leftcol or 0
   -- Gutter width (signcolumn + number + foldcolumn + statuscolumn). Buffer
   -- text starts at win_pos[2] + textoff, so Kitty placements need the same
@@ -1549,16 +1533,12 @@ function M.put_image(image_id, win, row, col, display_cols, display_rows, anim_p
     if type(border) == "table" then
       local left = border[8] -- 8th element = left border char
       if type(left) == "table" then left = left[1] end
-      if left and left ~= "" then
-        border_left_width = vim.api.nvim_strwidth(left)
-      end
+      if left and left ~= "" then border_left_width = vim.api.nvim_strwidth(left) end
       local top = border[2] -- 2nd element = top border char
       if type(top) == "table" then top = top[1] end
-      if top and top ~= "" then
-        border_top_height = 1
-      end
+      if top and top ~= "" then border_top_height = 1 end
     elseif border ~= "none" and border ~= "" then
-      border_left_width = vim.api.nvim_strwidth("│")
+      border_left_width = vim.api.nvim_strwidth "│"
       border_top_height = 1
     end
   end
@@ -1609,10 +1589,10 @@ function M.put_image(image_id, win, row, col, display_cols, display_rows, anim_p
   -- are placed one row too high and overlap any wrapped header lines below
   -- the image label (most visible with long alt text).
   local winbar_height = 0
-  local ok_wb, wb = pcall(function() return vim.wo[win].winbar end)
-  if ok_wb and wb and wb ~= "" then
-    winbar_height = 1
-  end
+  local ok_wb, wb = pcall(function()
+    return vim.wo[win].winbar
+  end)
+  if ok_wb and wb and wb ~= "" then winbar_height = 1 end
   local screen_row = wininfo.winrow + visual_row + border_top_height + winbar_height
 
   -- Bottom crop: image extends below visible area
@@ -1637,10 +1617,7 @@ function M.put_image(image_id, win, row, col, display_cols, display_rows, anim_p
   -- as "no crop" and silently scale the entire image into the display cells.
   local crop_params = ""
   if (src_x or src_y or src_w or src_h) and img_w and img_h then
-    crop_params = string.format(
-      ",x=%d,y=%d,w=%d,h=%d",
-      src_x or 0, src_y or 0, src_w or img_w, src_h or img_h
-    )
+    crop_params = string.format(",x=%d,y=%d,w=%d,h=%d", src_x or 0, src_y or 0, src_w or img_w, src_h or img_h)
   end
 
   local message
@@ -1652,20 +1629,22 @@ function M.put_image(image_id, win, row, col, display_cols, display_rows, anim_p
     local b64_path = vim.base64.encode(img_path)
     message = string.format(
       "\x1b_Ga=T,f=100,t=f,i=%d,c=%d,r=%d%s,C=1,q=2;%s\x1b\\",
-      image_id, display_cols, display_rows, crop_params, b64_path
+      image_id,
+      display_cols,
+      display_rows,
+      crop_params,
+      b64_path
     )
   else
     -- Static: put a previously transmitted image
-    message = string.format(
-      "\x1b_Ga=p,i=%d,c=%d,r=%d%s,C=1,q=2\x1b\\",
-      image_id, display_cols, display_rows, crop_params
-    )
+    message =
+      string.format("\x1b_Ga=p,i=%d,c=%d,r=%d%s,C=1,q=2\x1b\\", image_id, display_cols, display_rows, crop_params)
   end
 
-  term_write("\x1b[s")
+  term_write "\x1b[s"
   move_cursor(screen_col, screen_row)
   term_write(message)
-  term_write("\x1b[u")
+  term_write "\x1b[u"
 end
 
 --- Delete all placements for an image but keep the transmitted data.
@@ -1678,11 +1657,9 @@ end
 --- Delete all images and placements from terminal memory.
 function M.delete_all()
   if not M.supports_kitty() then return end
-  term_write("\x1b_Ga=d,d=A,q=2\x1b\\")
+  term_write "\x1b_Ga=d,d=A,q=2\x1b\\"
   for id, path in pairs(_image_paths) do
-    if _temp_image_paths[id] then
-      os.remove(path)
-    end
+    if _temp_image_paths[id] then os.remove(path) end
   end
   _image_paths = {}
   _temp_image_paths = {}
@@ -1724,13 +1701,11 @@ function M.clear_all()
   _session_cleared = true
   if not M.supports_kitty() then return end
   -- d=A: delete all stored image data and placements
-  term_write("\x1b_Ga=d,d=A\x1b\\")
+  term_write "\x1b_Ga=d,d=A\x1b\\"
   -- Reset ID counter and path mapping to ensure clean state
   _image_id = 100
   for id, path in pairs(_image_paths) do
-    if _temp_image_paths[id] then
-      os.remove(path)
-    end
+    if _temp_image_paths[id] then os.remove(path) end
   end
   _image_paths = {}
   _temp_image_paths = {}

--- a/lua/md-render/init.lua
+++ b/lua/md-render/init.lua
@@ -26,7 +26,8 @@ local ALERT_HL_BASES = {
 ---@return integer blended color
 local function blend_color(fg, bg, alpha)
   local r = math.floor(bit.rshift(fg, 16) * alpha + bit.rshift(bg, 16) * (1 - alpha) + 0.5)
-  local g = math.floor(bit.band(bit.rshift(fg, 8), 0xFF) * alpha + bit.band(bit.rshift(bg, 8), 0xFF) * (1 - alpha) + 0.5)
+  local g =
+    math.floor(bit.band(bit.rshift(fg, 8), 0xFF) * alpha + bit.band(bit.rshift(bg, 8), 0xFF) * (1 - alpha) + 0.5)
   local b = math.floor(bit.band(fg, 0xFF) * alpha + bit.band(bg, 0xFF) * (1 - alpha) + 0.5)
   return bit.lshift(r, 16) + bit.lshift(g, 8) + b
 end
@@ -55,9 +56,7 @@ end
 --- Set up alert highlight groups (MdRenderAlert* and MdRenderAlert*Bg)
 function M.setup_alert_highlights()
   local normal_hl = vim.api.nvim_get_hl(0, { name = "NormalFloat", link = false })
-  if not normal_hl.bg then
-    normal_hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
-  end
+  if not normal_hl.bg then normal_hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false }) end
   local normal_bg = normal_hl.bg or 0x1e1e2e
 
   for name, base_hl_name in pairs(ALERT_HL_BASES) do
@@ -71,9 +70,7 @@ end
 --- Set up <details> highlight groups (MdRenderDetailsBg)
 function M.setup_details_highlights()
   local normal_hl = vim.api.nvim_get_hl(0, { name = "NormalFloat", link = false })
-  if not normal_hl.bg then
-    normal_hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
-  end
+  if not normal_hl.bg then normal_hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false }) end
   local normal_bg = normal_hl.bg or 0x1e1e2e
 
   local border_hl = vim.api.nvim_get_hl(0, { name = "FloatBorder", link = false })
@@ -110,9 +107,7 @@ end
 --- Set up image placeholder highlight group (MdRenderImagePlaceholder)
 function M.setup_image_placeholder_highlight()
   local normal_hl = vim.api.nvim_get_hl(0, { name = "NormalFloat", link = false })
-  if not normal_hl.bg then
-    normal_hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
-  end
+  if not normal_hl.bg then normal_hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false }) end
   local normal_bg = normal_hl.bg or 0x1e1e2e
   local comment_hl = vim.api.nvim_get_hl(0, { name = "Comment", link = false })
   local fg = comment_hl.fg or 0x888888
@@ -126,9 +121,7 @@ end
 --- visually distinct from headings even when the colorscheme paints both green.
 function M.setup_inline_code_highlight()
   local normal_hl = vim.api.nvim_get_hl(0, { name = "NormalFloat", link = false })
-  if not normal_hl.bg then
-    normal_hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false })
-  end
+  if not normal_hl.bg then normal_hl = vim.api.nvim_get_hl(0, { name = "Normal", link = false }) end
   local normal_bg = normal_hl.bg or 0x1e1e2e
   local comment_hl = vim.api.nvim_get_hl(0, { name = "Comment", link = false })
   local tint = comment_hl.fg or 0x888888

--- a/lua/md-render/markdown.lua
+++ b/lua/md-render/markdown.lua
@@ -166,8 +166,8 @@ end
 local function restore_backslashes(text, escapes, highlights, links)
   if #escapes == 0 then return text end
   local result = {}
-  local byte_offset = 0  -- cumulative byte shift (3-byte placeholder → 1-byte char = -2 each)
-  local offsets = {}      -- {pos_in_output, delta} for position adjustments
+  local byte_offset = 0 -- cumulative byte shift (3-byte placeholder → 1-byte char = -2 each)
+  local offsets = {} -- {pos_in_output, delta} for position adjustments
   local i = 1
   while i <= #text do
     local b1 = text:byte(i)
@@ -194,9 +194,7 @@ local function restore_backslashes(text, escapes, highlights, links)
     local function adjust(pos)
       local shift = 0
       for _, o in ipairs(offsets) do
-        if pos > o.pos then
-          shift = shift + o.delta
-        end
+        if pos > o.pos then shift = shift + o.delta end
       end
       return pos - shift
     end
@@ -219,17 +217,46 @@ end
 
 --- Common HTML named character references
 local HTML_ENTITIES = {
-  amp = "&", lt = "<", gt = ">", quot = '"', apos = "'",
+  amp = "&",
+  lt = "<",
+  gt = ">",
+  quot = '"',
+  apos = "'",
   nbsp = "\194\160", -- U+00A0
-  ndash = "–", mdash = "—", lsquo = "\226\128\152", rsquo = "\226\128\153",
-  ldquo = "\226\128\156", rdquo = "\226\128\157", bull = "•",
-  hellip = "…", copy = "©", reg = "®", trade = "™",
-  laquo = "«", raquo = "»", middot = "·", times = "×", divide = "÷",
-  plusmn = "±", micro = "µ", para = "¶", sect = "§", deg = "°",
-  frac14 = "¼", frac12 = "½", frac34 = "¾",
-  larr = "←", rarr = "→", uarr = "↑", darr = "↓",
-  hearts = "♥", diams = "♦", clubs = "♣", spades = "♠",
-  checkmark = "✓", cross = "✗",
+  ndash = "–",
+  mdash = "—",
+  lsquo = "\226\128\152",
+  rsquo = "\226\128\153",
+  ldquo = "\226\128\156",
+  rdquo = "\226\128\157",
+  bull = "•",
+  hellip = "…",
+  copy = "©",
+  reg = "®",
+  trade = "™",
+  laquo = "«",
+  raquo = "»",
+  middot = "·",
+  times = "×",
+  divide = "÷",
+  plusmn = "±",
+  micro = "µ",
+  para = "¶",
+  sect = "§",
+  deg = "°",
+  frac14 = "¼",
+  frac12 = "½",
+  frac34 = "¾",
+  larr = "←",
+  rarr = "→",
+  uarr = "↑",
+  darr = "↓",
+  hearts = "♥",
+  diams = "♦",
+  clubs = "♣",
+  spades = "♠",
+  checkmark = "✓",
+  cross = "✗",
 }
 
 --- Encode a Unicode codepoint as a UTF-8 string
@@ -269,9 +296,7 @@ local function decode_html_entities(text, highlights, links)
       local num_match, num_end = text:match("^(&#(%d+);)", i)
       if not num_match then
         num_match, num_end = text:match("^(&#[xX](%x+);)", i)
-        if num_match then
-          num_end = tonumber(num_end, 16)
-        end
+        if num_match then num_end = tonumber(num_end, 16) end
       else
         num_end = tonumber(num_end)
       end
@@ -279,9 +304,7 @@ local function decode_html_entities(text, highlights, links)
         local replacement = utf8_char(num_end)
         local out_pos = #table.concat(result)
         local delta = #num_match - #replacement
-        if delta ~= 0 then
-          table.insert(offsets, { pos = out_pos, delta = delta })
-        end
+        if delta ~= 0 then table.insert(offsets, { pos = out_pos, delta = delta }) end
         table.insert(result, replacement)
         i = i + #num_match
       else
@@ -293,9 +316,7 @@ local function decode_html_entities(text, highlights, links)
             local full = "&" .. name .. ";"
             local out_pos = #table.concat(result)
             local delta = #full - #replacement
-            if delta ~= 0 then
-              table.insert(offsets, { pos = out_pos, delta = delta })
-            end
+            if delta ~= 0 then table.insert(offsets, { pos = out_pos, delta = delta }) end
             table.insert(result, replacement)
             i = i + #full
           else
@@ -317,9 +338,7 @@ local function decode_html_entities(text, highlights, links)
     local function adjust(pos)
       local shift = 0
       for _, o in ipairs(offsets) do
-        if pos > o.pos then
-          shift = shift + o.delta
-        end
+        if pos > o.pos then shift = shift + o.delta end
       end
       return pos - shift
     end
@@ -341,9 +360,7 @@ end
 ---@param icon string single icon character
 ---@return string
 local function pad_icon(icon)
-  if vim.api.nvim_strwidth(icon) == 1 then
-    return icon .. " "
-  end
+  if vim.api.nvim_strwidth(icon) == 1 then return icon .. " " end
   return icon
 end
 
@@ -385,9 +402,7 @@ local ALERT_TYPES = {
 ---@param hl_count integer number of highlights to adjust (from the beginning)
 ---@param link_count integer number of links to adjust (from the beginning)
 local function adjust_positions(highlights, links, removals, hl_count, link_count)
-  if #removals == 0 then
-    return
-  end
+  if #removals == 0 then return end
   local function adjust(pos)
     local shift = 0
     for _, r in ipairs(removals) do
@@ -642,7 +657,10 @@ local function process_embeds(text, highlights, links)
         if embed_icon_hl then
           table.insert(highlights, { col = start_col, end_col = start_col + #icon - 1, hl = embed_icon_hl })
         end
-        table.insert(highlights, { col = start_col + #icon, end_col = start_col + #display, hl = "MdRenderLinkObsidian" })
+        table.insert(
+          highlights,
+          { col = start_col + #icon, end_col = start_col + #display, hl = "MdRenderLinkObsidian" }
+        )
         table.insert(links, {
           col_start = start_col,
           col_end = start_col + #display,
@@ -730,9 +748,7 @@ end
 ---@param links MdRender.Markdown.Link[]
 ---@return string processed
 local function process_reference_links(text, ref_links, highlights, links)
-  if not ref_links or not next(ref_links) then
-    return text
-  end
+  if not ref_links or not next(ref_links) then return text end
   local pre_hl_count = #highlights
   local pre_link_count = #links
   local removals = {}
@@ -749,9 +765,7 @@ local function process_reference_links(text, ref_links, highlights, links)
           if close2 then
             local ref = text:sub(close + 2, close2 - 1)
             -- Collapsed reference link: [text][] uses label as ref
-            if ref == "" then
-              ref = label
-            end
+            if ref == "" then ref = label end
             local url = ref_links[ref:lower()]
             if url then
               local start_col = #processed
@@ -833,14 +847,12 @@ local function process_bare_urls(text, max_url_width, highlights, links)
           local start_col = #processed
           local display_url
           if vim.api.nvim_strwidth(captured) > max_url_width then
-            local target = max_url_width - vim.api.nvim_strwidth("…")
+            local target = max_url_width - vim.api.nvim_strwidth "…"
             local current_width = 0
             local byte_pos = 0
             for char in captured:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
               local char_width = vim.api.nvim_strwidth(char)
-              if current_width + char_width > target then
-                break
-              end
+              if current_width + char_width > target then break end
               current_width = current_width + char_width
               byte_pos = byte_pos + #char
             end
@@ -865,53 +877,51 @@ local function process_bare_urls(text, max_url_width, highlights, links)
         end
       end
       if not handled_autolink then
-      local s, e = text:find("https?://[^%s%)<>\"]+", i)
-      if s == i then
-        local url_match = text:sub(s, e)
-        -- Strip trailing punctuation (including markdown markers)
-        local url = url_match:gsub("[.,;:!?*~]+$", "")
-        -- Strip trailing non-ASCII symbols (e.g. ⏎, →) that are not valid in URLs.
-        -- charclass returns 1 for punctuation/symbols, >=2 for letters/digits.
-        while #url > 0 do
-          local last_char = vim.fn.strcharpart(url, vim.fn.strchars(url) - 1, 1)
-          if #last_char > 1 and vim.fn.charclass(last_char) <= 1 then
-            url = url:sub(1, #url - #last_char)
-          else
-            break
-          end
-        end
-        local start_col = #processed
-        local display_url
-
-        if vim.api.nvim_strwidth(url) > max_url_width then
-          local target = max_url_width - vim.api.nvim_strwidth("…")
-          local current_width = 0
-          local byte_pos = 0
-          for char in url:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
-            local char_width = vim.api.nvim_strwidth(char)
-            if current_width + char_width > target then
+        local s, e = text:find('https?://[^%s%)<>"]+', i)
+        if s == i then
+          local url_match = text:sub(s, e)
+          -- Strip trailing punctuation (including markdown markers)
+          local url = url_match:gsub("[.,;:!?*~]+$", "")
+          -- Strip trailing non-ASCII symbols (e.g. ⏎, →) that are not valid in URLs.
+          -- charclass returns 1 for punctuation/symbols, >=2 for letters/digits.
+          while #url > 0 do
+            local last_char = vim.fn.strcharpart(url, vim.fn.strchars(url) - 1, 1)
+            if #last_char > 1 and vim.fn.charclass(last_char) <= 1 then
+              url = url:sub(1, #url - #last_char)
+            else
               break
             end
-            current_width = current_width + char_width
-            byte_pos = byte_pos + #char
           end
-          display_url = url:sub(1, byte_pos) .. "…"
-          table.insert(adjustments, {
-            input_pos = i - 1 + byte_pos,
-            delta = #url - byte_pos - #"…",
-          })
-        else
-          display_url = url
-        end
+          local start_col = #processed
+          local display_url
 
-        processed = processed .. display_url
-        table.insert(highlights, { col = start_col, end_col = start_col + #display_url, hl = "Underlined" })
-        table.insert(links, { col_start = start_col, col_end = start_col + #display_url, url = url })
-        i = i + #url
-      else
-        processed = processed .. text:sub(i, i)
-        i = i + 1
-      end
+          if vim.api.nvim_strwidth(url) > max_url_width then
+            local target = max_url_width - vim.api.nvim_strwidth "…"
+            local current_width = 0
+            local byte_pos = 0
+            for char in url:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
+              local char_width = vim.api.nvim_strwidth(char)
+              if current_width + char_width > target then break end
+              current_width = current_width + char_width
+              byte_pos = byte_pos + #char
+            end
+            display_url = url:sub(1, byte_pos) .. "…"
+            table.insert(adjustments, {
+              input_pos = i - 1 + byte_pos,
+              delta = #url - byte_pos - #"…",
+            })
+          else
+            display_url = url
+          end
+
+          processed = processed .. display_url
+          table.insert(highlights, { col = start_col, end_col = start_col + #display_url, hl = "Underlined" })
+          table.insert(links, { col_start = start_col, col_end = start_col + #display_url, url = url })
+          i = i + #url
+        else
+          processed = processed .. text:sub(i, i)
+          i = i + 1
+        end
       end -- if not handled_autolink
     else
       processed = processed .. text:sub(i, i)
@@ -923,9 +933,7 @@ local function process_bare_urls(text, max_url_width, highlights, links)
     local function adjust(pos)
       local total_delta = 0
       for _, adj in ipairs(adjustments) do
-        if pos > adj.input_pos then
-          total_delta = total_delta + adj.delta
-        end
+        if pos > adj.input_pos then total_delta = total_delta + adj.delta end
       end
       return pos - total_delta
     end
@@ -1141,8 +1149,7 @@ local function process_html_tags(text, highlights, links)
         if video_tag then
           local src = video_tag:match 'src="([^"]*)"' or video_tag:match "src='([^']*)'"
           if not src then
-            src = video_tag:match '<source[^>]*src="([^"]*)"'
-              or video_tag:match "<source[^>]*src='([^']*)'>"
+            src = video_tag:match '<source[^>]*src="([^"]*)"' or video_tag:match "<source[^>]*src='([^']*)'>"
           end
           if src then
             local icons_mod = require "md-render.icons"
@@ -1185,9 +1192,7 @@ local function process_html_tags(text, highlights, links)
                 table.insert(removals, { start = close_start - 1, count = #close_tag })
                 local start_col = #processed
                 processed = processed .. content
-                if hl then
-                  table.insert(highlights, { col = start_col, end_col = start_col + #content, hl = hl })
-                end
+                if hl then table.insert(highlights, { col = start_col, end_col = start_col + #content, hl = hl }) end
                 i = close_start + #close_tag
                 matched = true
               end
@@ -1273,9 +1278,7 @@ end
 ---@param links MdRender.Markdown.Link[]
 ---@return string processed
 local function process_footnote_refs(text, footnote_map, highlights, links)
-  if not footnote_map or not next(footnote_map) then
-    return text
-  end
+  if not footnote_map or not next(footnote_map) then return text end
   local processed = ""
   local i = 1
   while i <= #text do
@@ -1289,7 +1292,10 @@ local function process_footnote_refs(text, footnote_map, highlights, links)
           local start_col = #processed
           processed = processed .. display
           table.insert(highlights, { col = start_col, end_col = start_col + #display, hl = "Special" })
-          table.insert(links, { col_start = start_col, col_end = start_col + #display, url = "#footnote-def-" .. label })
+          table.insert(
+            links,
+            { col_start = start_col, col_end = start_col + #display, url = "#footnote-def-" .. label }
+          )
           i = close + 1
         else
           processed = processed .. text:sub(i, i)
@@ -1467,8 +1473,7 @@ Markdown.render = function(text, repo_base_url, autolinks, ref_links, footnote_m
   end
 
   -- List items (- * + 1. 1)) - detect marker
-  local list_marker = rendered_text:match "^(%s*[-*+]%s)"
-    or rendered_text:match "^(%s*%d+[.)]%s)"
+  local list_marker = rendered_text:match "^(%s*[-*+]%s)" or rendered_text:match "^(%s*%d+[.)]%s)"
 
   -- Checkbox (- [ ] / - [x] / - [X] / - [-]) - replace marker + checkbox with icon
   local checkbox_hl = nil
@@ -1478,13 +1483,13 @@ Markdown.render = function(text, repo_base_url, autolinks, ref_links, footnote_m
     if cb_match then
       local icon
       if cb_char == " " then
-        icon = pad_icon("󰄱") .. " "
+        icon = pad_icon "󰄱" .. " "
         checkbox_hl = "Comment"
       elseif cb_char == "-" then
-        icon = pad_icon("󰡖") .. " "
+        icon = pad_icon "󰡖" .. " "
         checkbox_hl = "DiagnosticWarn"
       else
-        icon = pad_icon("󰄲") .. " "
+        icon = pad_icon "󰄲" .. " "
         checkbox_hl = "DiagnosticOk"
       end
       local indent_part = list_marker:match "^(%s*)" or ""
@@ -1518,17 +1523,15 @@ Markdown.render = function(text, repo_base_url, autolinks, ref_links, footnote_m
   -- no markdown-significant characters.  This dramatically speeds up rendering
   -- of large documents (e.g. classical Chinese texts) where most lines are
   -- pure prose with no formatting.
-  local needs_inline = rendered_text:find("[%*_~`%[<>=!$\\&#%%]")
-    or rendered_text:find("https?://")
+  local needs_inline = rendered_text:find "[%*_~`%[<>=!$\\&#%%]"
+    or rendered_text:find "https?://"
     or (autolinks and #autolinks > 0)
-    or (footnote_map and next(footnote_map) and rendered_text:find("%[%^"))
+    or (footnote_map and next(footnote_map) and rendered_text:find "%[%^")
   -- Declare locals before the fast-path goto so they are in scope at ::finalize::
   local code_spans
   local backslash_escapes
 
-  if not needs_inline then
-    goto finalize
-  end
+  if not needs_inline then goto finalize end
 
   -- Protect code spans before any inline processing (code spans take precedence)
   rendered_text, code_spans = protect_code_spans(rendered_text)
@@ -1548,9 +1551,7 @@ Markdown.render = function(text, repo_base_url, autolinks, ref_links, footnote_m
   until rendered_text == prev
   rendered_text = strip_html_tags(rendered_text, highlights)
   rendered_text = process_bare_urls(rendered_text, MAX_URL_DISPLAY_WIDTH, highlights, links)
-  if repo_base_url then
-    rendered_text = process_issue_refs(rendered_text, repo_base_url, highlights, links)
-  end
+  if repo_base_url then rendered_text = process_issue_refs(rendered_text, repo_base_url, highlights, links) end
   if autolinks and #autolinks > 0 then
     rendered_text = process_autolink_refs(rendered_text, autolinks, highlights, links)
   end
@@ -1636,9 +1637,7 @@ Markdown.parse_footnotes = function(lines)
   end
 
   for _, line in ipairs(lines) do
-    if line:match "^```" then
-      in_code = not in_code
-    end
+    if line:match "^```" then in_code = not in_code end
     if in_code then goto continue end
 
     local label, text = line:match "^%[%^([^%]]+)%]:%s+(.+)$"
@@ -1696,13 +1695,9 @@ end
 ---@return string? marker_type
 Markdown.list_marker_type = function(line)
   local bullet = line:match "^%s*([-*+])%s"
-  if bullet then
-    return bullet
-  end
+  if bullet then return bullet end
   local delim = line:match "^%s*%d+([.)])%s"
-  if delim then
-    return delim
-  end
+  if delim then return delim end
   return nil
 end
 
@@ -1730,9 +1725,7 @@ Markdown.renumber_ordered_lists = function(lines)
       end
       table.insert(result, prefix .. tostring(stack[#stack].counter) .. rest)
     else
-      if not line:match "^%s*$" then
-        stack = {}
-      end
+      if not line:match "^%s*$" then stack = {} end
       table.insert(result, line)
     end
   end

--- a/lua/md-render/markdown_table.lua
+++ b/lua/md-render/markdown_table.lua
@@ -18,18 +18,12 @@ local wrap_mod = require "md-render.wrap"
 local function split_row(line)
   -- Strip leading whitespace, then expect |
   local stripped = line:match "^%s*(.*)" or line
-  if stripped:sub(1, 1) ~= "|" then
-    return nil
-  end
+  if stripped:sub(1, 1) ~= "|" then return nil end
   -- Remove leading and trailing |
   local inner = stripped:match "^|(.*)$"
-  if not inner then
-    return nil
-  end
+  if not inner then return nil end
   -- Remove trailing | if present (but not escaped \|)
-  if inner:sub(-1) == "|" and inner:sub(-2, -2) ~= "\\" then
-    inner = inner:sub(1, -2)
-  end
+  if inner:sub(-1) == "|" and inner:sub(-2, -2) ~= "\\" then inner = inner:sub(1, -2) end
   local cells = {}
   local pos = 1
   while pos <= #inner do
@@ -61,15 +55,11 @@ end
 ---@return string[]|nil alignments array or nil if not a separator
 local function parse_separator(line)
   local cells = split_row(line)
-  if not cells or #cells == 0 then
-    return nil
-  end
+  if not cells or #cells == 0 then return nil end
   local alignments = {}
   for _, cell in ipairs(cells) do
     -- Must match pattern: optional :, one or more -, optional :
-    if not cell:match "^:?%-+:?$" then
-      return nil
-    end
+    if not cell:match "^:?%-+:?$" then return nil end
     local left = cell:sub(1, 1) == ":"
     local right = cell:sub(-1) == ":"
     if left and right then
@@ -107,9 +97,7 @@ end
 ---@param max_display_width integer
 ---@return {text: string, byte_start: integer}[]
 local function wrap_cell_text(text, max_display_width)
-  if vim.api.nvim_strwidth(text) <= max_display_width then
-    return { { text = text, byte_start = 0 } }
-  end
+  if vim.api.nvim_strwidth(text) <= max_display_width then return { { text = text, byte_start = 0 } } end
 
   local wrapped_lines, line_starts = wrap_mod.wrap_words(text, max_display_width)
   local result = {}
@@ -127,9 +115,7 @@ local function wrap_cell_text(text, max_display_width)
             current_byte = seg.byte_pos
             current_text = seg.text
           else
-            if current_text == "" then
-              current_byte = seg.byte_pos
-            end
+            if current_text == "" then current_byte = seg.byte_pos end
             current_text = current_text .. seg.text
           end
         end
@@ -171,9 +157,7 @@ local function wrap_cell_text(text, max_display_width)
               current_byte = byte_offset
               current_text = g
             else
-              if current_text == "" then
-                current_byte = byte_offset
-              end
+              if current_text == "" then current_byte = byte_offset end
               current_text = current_text .. g
             end
             byte_offset = byte_offset + #g
@@ -201,21 +185,15 @@ end
 ---@return integer byte_length of the kept portion (before "…")
 local function truncate_to_width(text, max_display_width)
   local text_width = vim.api.nvim_strwidth(text)
-  if text_width <= max_display_width then
-    return text, #text
-  end
-  local ellipsis_width = vim.api.nvim_strwidth("…")
+  if text_width <= max_display_width then return text, #text end
+  local ellipsis_width = vim.api.nvim_strwidth "…"
   local target = max_display_width - ellipsis_width
-  if target <= 0 then
-    return "…", 0
-  end
+  if target <= 0 then return "…", 0 end
   local current_width = 0
   local byte_pos = 0
   for char in text:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
     local char_width = vim.api.nvim_strwidth(char)
-    if current_width + char_width > target then
-      break
-    end
+    if current_width + char_width > target then break end
     current_width = current_width + char_width
     byte_pos = byte_pos + #char
   end
@@ -231,9 +209,7 @@ end
 local function pad_cell(text, width, align)
   local text_width = vim.api.nvim_strwidth(text)
   local total_pad = width - text_width
-  if total_pad <= 0 then
-    return text, 0
-  end
+  if total_pad <= 0 then return text, 0 end
   if align == "right" then
     return string.rep(" ", total_pad) .. text, total_pad
   elseif align == "center" then
@@ -251,26 +227,18 @@ end
 ---@param autolinks? MdRender.Autolink[]
 ---@return MdRender.MarkdownTable.ParsedTable|nil
 function MarkdownTable.parse(lines, repo_base_url, autolinks)
-  if #lines < 2 then
-    return nil
-  end
+  if #lines < 2 then return nil end
 
   -- Line 1: header row
   local header_cells = split_row(lines[1])
-  if not header_cells or #header_cells == 0 then
-    return nil
-  end
+  if not header_cells or #header_cells == 0 then return nil end
 
   -- Line 2: separator row
   local alignments = parse_separator(lines[2])
-  if not alignments then
-    return nil
-  end
+  if not alignments then return nil end
 
   -- Column count must match
-  if #header_cells ~= #alignments then
-    return nil
-  end
+  if #header_cells ~= #alignments then return nil end
 
   -- Process header cells
   local headers = {}
@@ -282,9 +250,7 @@ function MarkdownTable.parse(lines, repo_base_url, autolinks)
   local rows = {}
   for i = 3, #lines do
     local cells = split_row(lines[i])
-    if not cells then
-      break
-    end
+    if not cells then break end
     local row = {}
     for col = 1, #alignments do
       local cell_text = cells[col] or ""
@@ -298,9 +264,7 @@ function MarkdownTable.parse(lines, repo_base_url, autolinks)
   for col = 1, #alignments do
     local w = vim.api.nvim_strwidth(headers[col].text)
     for _, row in ipairs(rows) do
-      if row[col] then
-        w = math.max(w, vim.api.nvim_strwidth(row[col].text))
-      end
+      if row[col] then w = math.max(w, vim.api.nvim_strwidth(row[col].text)) end
     end
     col_widths[col] = w
   end
@@ -344,13 +308,13 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
   local out_source_offsets = {}
   local num_cols = #parsed_table.col_widths
   local col_widths = vim.deepcopy(parsed_table.col_widths)
-  local sep_width = vim.api.nvim_strwidth("│") -- border char display width (varies with ambiwidth)
+  local sep_width = vim.api.nvim_strwidth "│" -- border char display width (varies with ambiwidth)
 
   --- Strip leading HTML comments from text
   ---@param text string
   ---@return string
   local function strip_html_comments(text)
-    return text:gsub("<!%-%-.-%-%->" , ""):match "^%s*(.-)%s*$"
+    return text:gsub("<!%-%-.-%-%->", ""):match "^%s*(.-)%s*$"
   end
 
   --- Check if a cell contains only an image reference ![alt](url), <img>, or <video> tag
@@ -380,8 +344,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
     if video_tag then
       local src = video_tag:match 'src="([^"]*)"' or video_tag:match "src='([^']*)'"
       if not src then
-        src = video_tag:match '<source[^>]*src="([^"]*)"'
-          or video_tag:match "<source[^>]*src='([^']*)'>"
+        src = video_tag:match '<source[^>]*src="([^"]*)"' or video_tag:match "<source[^>]*src='([^']*)'>"
       end
       if src then
         alt = src:match "([^/]+)$" or src
@@ -413,7 +376,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
   do
     local image_mod = require "md-render.image"
     if image_mod.supports_kitty() then
-      buf_dir = buf_dir or vim.fn.expand("%:p:h")
+      buf_dir = buf_dir or vim.fn.expand "%:p:h"
       local indent_width = vim.api.nvim_strwidth(indent)
       local overhead = indent_width + num_cols * (sep_width + 2) + sep_width
       local effective_max = max_width and max_width < 1e6 and max_width or 1e6
@@ -434,12 +397,8 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
                     resolved = image_mod.get_video_cached(src_url)
                   else
                     local video_path = vim.fn.expand(url)
-                    if video_path:sub(1, 1) ~= "/" and buf_dir then
-                      video_path = buf_dir .. "/" .. video_path
-                    end
-                    if vim.fn.filereadable(video_path) == 1 then
-                      resolved = video_path
-                    end
+                    if video_path:sub(1, 1) ~= "/" and buf_dir then video_path = buf_dir .. "/" .. video_path end
+                    if vim.fn.filereadable(video_path) == 1 then resolved = video_path end
                     -- Fallback: try Obsidian vault resolution for local video files
                     if not resolved and buf_dir then
                       local obsidian = require "md-render.obsidian"
@@ -464,8 +423,12 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
                   local display_cols = image_mod.calc_display_size(img_w, img_h, initial_max_per_col, 15)
                   if not row_images_cache[row_idx] then row_images_cache[row_idx] = {} end
                   row_images_cache[row_idx][col] = {
-                    alt = alt, url = url, resolved = resolved,
-                    img_w = img_w, img_h = img_h, video = is_video,
+                    alt = alt,
+                    url = url,
+                    resolved = resolved,
+                    img_w = img_w,
+                    img_h = img_h,
+                    video = is_video,
                   }
                   col_image_widths[col] = math.max(col_image_widths[col] or 0, display_cols)
                   has_image_cells = true
@@ -473,14 +436,21 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
                   -- Auto-detected video with resolved path but no dimensions yet
                   if not row_images_cache[row_idx] then row_images_cache[row_idx] = {} end
                   row_images_cache[row_idx][col] = {
-                    alt = alt, url = url, resolved = resolved, video = true,
+                    alt = alt,
+                    url = url,
+                    resolved = resolved,
+                    video = true,
                   }
                   col_image_widths[col] = math.max(col_image_widths[col] or 0, initial_max_per_col)
                   has_image_cells = true
                 elseif src_url then
                   if not row_images_cache[row_idx] then row_images_cache[row_idx] = {} end
                   row_images_cache[row_idx][col] = {
-                    alt = alt, url = url, resolved = nil, src_url = src_url, video = is_video,
+                    alt = alt,
+                    url = url,
+                    resolved = nil,
+                    src_url = src_url,
+                    video = is_video,
                   }
                   col_image_widths[col] = math.max(col_image_widths[col] or 0, initial_max_per_col)
                   has_image_cells = true
@@ -498,7 +468,9 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
           if cells then
             for _, cell_text in ipairs(cells) do
               local trimmed = strip_html_comments(cell_text)
-              if trimmed and (trimmed:match "^!%[.-%]%(.-%)" or trimmed:match "^<img%s" or trimmed:match "^<video[%s>]") then
+              if
+                trimmed and (trimmed:match "^!%[.-%]%(.-%)" or trimmed:match "^<img%s" or trimmed:match "^<video[%s>]")
+              then
                 has_image_cells = true
                 break
               end
@@ -525,9 +497,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
     if has_image_cells then
       -- Ensure columns are wide enough for actual image display sizes
       for col = 1, num_cols do
-        if col_image_widths[col] then
-          col_widths[col] = math.max(col_widths[col], col_image_widths[col])
-        end
+        if col_image_widths[col] then col_widths[col] = math.max(col_widths[col], col_image_widths[col]) end
       end
       if expanded then
         -- Expanded: also ensure columns fit full image labels (no truncation)
@@ -550,9 +520,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
     total = overhead + content_sum
     if total > max_width then
       local budget = max_width - overhead
-      if budget < num_cols then
-        budget = num_cols
-      end
+      if budget < num_cols then budget = num_cols end
       -- In expanded mode, content wraps so no column needs more than the full
       -- budget.  Cap each column's width for proportion calculation to prevent
       -- columns with very long content from starving shorter columns.
@@ -593,9 +561,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
   -- When expanded, ensure minimum column width of 2 to prevent CJK character overflow
   if expanded then
     for col = 1, num_cols do
-      if col_widths[col] < 2 then
-        col_widths[col] = 2
-      end
+      if col_widths[col] < 2 then col_widths[col] = 2 end
     end
   end
 
@@ -909,21 +875,31 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
         if img.img_w and img.img_h then
           local display_cols, display_rows = image_mod.calc_display_size(img.img_w, img.img_h, col_widths[col], 15)
           row_images[col] = {
-            alt = img.alt, url = img.url, resolved = img.resolved,
-            display_cols = display_cols, display_rows = display_rows,
+            alt = img.alt,
+            url = img.url,
+            resolved = img.resolved,
+            display_cols = display_cols,
+            display_rows = display_rows,
             video = img.video,
           }
         elseif img.resolved and img.video then
           -- Auto-detected video: resolved path but no dimensions yet
           row_images[col] = {
-            alt = img.alt, url = img.url, resolved = img.resolved,
-            display_cols = col_widths[col], display_rows = 10,
+            alt = img.alt,
+            url = img.url,
+            resolved = img.resolved,
+            display_cols = col_widths[col],
+            display_rows = 10,
             video = true,
           }
         elseif img.src_url then
           row_images[col] = {
-            alt = img.alt, url = img.url, resolved = nil, src_url = img.src_url,
-            display_cols = col_widths[col], display_rows = 10,
+            alt = img.alt,
+            url = img.url,
+            resolved = nil,
+            src_url = img.src_url,
+            display_cols = col_widths[col],
+            display_rows = 10,
             video = img.video,
           }
         end
@@ -949,9 +925,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
           local lbl_hls = {
             { col = #img_icon + 1, end_col = #label, hl = "Comment" },
           }
-          if icon_hl then
-            table.insert(lbl_hls, 1, { col = 0, end_col = #img_icon, hl = icon_hl })
-          end
+          if icon_hl then table.insert(lbl_hls, 1, { col = 0, end_col = #img_icon, hl = icon_hl }) end
           label_cells[col] = {
             text = label,
             highlights = lbl_hls,
@@ -964,9 +938,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
       -- Center-align image label cells
       local img_align_overrides = {}
       for col = 1, num_cols do
-        if row_images[col] then
-          img_align_overrides[col] = "center"
-        end
+        if row_images[col] then img_align_overrides[col] = "center" end
       end
       local label_line, label_hls, label_links = build_row(label_cells, false, img_align_overrides)
       table.insert(out_lines, label_line)
@@ -975,7 +947,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
       table.insert(out_source_offsets, 1 + row_idx) -- data row N -> offset 1+N (separator at 1)
 
       -- Add placeholder rows for images
-      local img_start_line_idx = #out_lines  -- 0-indexed line where images start
+      local img_start_line_idx = #out_lines -- 0-indexed line where images start
       for _ = 1, max_img_rows do
         local empty_line, empty_hls = build_empty_row()
         table.insert(out_lines, empty_line)
@@ -998,9 +970,7 @@ function MarkdownTable.render(parsed_table, indent, max_width, expanded, buf_dir
         -- When the gap is odd, expand the image by 1 cell so centering is symmetric.
         local img_cols = img.display_cols
         local diff = col_widths[col] - img_cols
-        if diff > 0 and diff % 2 == 1 then
-          img_cols = img_cols + 1
-        end
+        if diff > 0 and diff % 2 == 1 then img_cols = img_cols + 1 end
         local center_pad = math.max(0, math.floor((col_widths[col] - img_cols) / 2))
         col_display_offset = col_display_offset + center_pad
 

--- a/lua/md-render/obsidian.lua
+++ b/lua/md-render/obsidian.lua
@@ -18,9 +18,7 @@ local _file_cache = {}
 function M.find_vault_root(buf_dir)
   if _vault_cache[buf_dir] ~= nil then
     local cached = _vault_cache[buf_dir]
-    if cached then
-      return cached.vault_root or nil
-    end
+    if cached then return cached.vault_root or nil end
     return nil
   end
 
@@ -30,9 +28,7 @@ function M.find_vault_root(buf_dir)
     if dir ~= buf_dir and _vault_cache[dir] ~= nil then
       _vault_cache[buf_dir] = _vault_cache[dir]
       local cached = _vault_cache[dir]
-      if cached then
-        return cached.vault_root or nil
-      end
+      if cached then return cached.vault_root or nil end
       return nil
     end
 
@@ -58,9 +54,7 @@ end
 function M.get_attachment_folder(vault_root)
   local info = _vault_cache[vault_root]
   if info and info.attachment_folder ~= nil then
-    if info.attachment_folder then
-      return info.attachment_folder
-    end
+    if info.attachment_folder then return info.attachment_folder end
     return nil
   end
 
@@ -103,9 +97,7 @@ function M.resolve(filename, buf_dir)
   local cache_key = vault_root .. ":" .. basename
   local cached = _file_cache[cache_key]
   if cached then
-    if vim.fn.filereadable(cached) == 1 then
-      return cached
-    end
+    if vim.fn.filereadable(cached) == 1 then return cached end
     _file_cache[cache_key] = nil
   end
 

--- a/lua/md-render/preview.lua
+++ b/lua/md-render/preview.lua
@@ -103,14 +103,12 @@ MdPreview.build_content = function(lines, opts)
           local full_line = label .. ": " .. entry.value
           local display_width = vim.api.nvim_strwidth(full_line)
           if display_width > max_width then
-            local target = max_width - vim.api.nvim_strwidth("…")
+            local target = max_width - vim.api.nvim_strwidth "…"
             local current_width = 0
             local byte_pos = 0
             for char in full_line:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
               local char_width = vim.api.nvim_strwidth(char)
-              if current_width + char_width > target then
-                break
-              end
+              if current_width + char_width > target then break end
               current_width = current_width + char_width
               byte_pos = byte_pos + #char
             end
@@ -255,7 +253,9 @@ function Session:rebuild()
   local saved_views = {}
   for _, w in ipairs(wins) do
     if vim.api.nvim_win_is_valid(w) then
-      saved_views[w] = vim.api.nvim_win_call(w, function() return vim.fn.winsaveview() end)
+      saved_views[w] = vim.api.nvim_win_call(w, function()
+        return vim.fn.winsaveview()
+      end)
     end
   end
 
@@ -268,15 +268,18 @@ function Session:rebuild()
   vim.bo[self.buf].modified = false
 
   for w, view in pairs(saved_views) do
-    if vim.api.nvim_win_is_valid(w) then
-      vim.api.nvim_win_call(w, function() vim.fn.winrestview(view) end)
-    end
+    if vim.api.nvim_win_is_valid(w) then vim.api.nvim_win_call(w, function()
+      vim.fn.winrestview(view)
+    end) end
   end
 
   if self.win and vim.api.nvim_win_is_valid(self.win) then
     local any_expanded = false
     for _, v in pairs(self.expand_state) do
-      if v then any_expanded = true; break end
+      if v then
+        any_expanded = true
+        break
+      end
     end
     vim.api.nvim_set_option_value("wrap", not any_expanded, { win = self.win })
   end
@@ -325,7 +328,11 @@ local function bracket_index(pts, key, value)
   if value >= pts[hi][key] then return hi end
   while lo + 1 < hi do
     local mid = math.floor((lo + hi) / 2)
-    if pts[mid][key] <= value then lo = mid else hi = mid end
+    if pts[mid][key] <= value then
+      lo = mid
+    else
+      hi = mid
+    end
   end
   return lo
 end
@@ -453,7 +460,9 @@ function Session:install_float_keymaps(close_handle, keymap_opts)
   display_utils.setup_float_keymaps(self.buf, self.ns, self.win, self.content, close_handle, {
     close_keys = keymap_opts.close_keys,
     close_line_idx = keymap_opts.close_line_idx,
-    get_content = function() return self.content end,
+    get_content = function()
+      return self.content
+    end,
     on_fold_toggle = function(source_line, collapsed)
       self.fold_state[source_line] = collapsed
       self:rebuild()
@@ -478,13 +487,11 @@ function Session:install_cursor_sync()
   vim.api.nvim_create_autocmd("CursorMoved", {
     buffer = self.buf,
     callback = function()
-      if vim.api.nvim_win_is_valid(win) then
-        last_preview_line = vim.api.nvim_win_get_cursor(win)[1]
-      end
+      if vim.api.nvim_win_is_valid(win) then last_preview_line = vim.api.nvim_win_get_cursor(win)[1] end
     end,
   })
 
-  local content_ref = self.content  -- captured at install time; updated by rebuild via self.content
+  local content_ref = self.content -- captured at install time; updated by rebuild via self.content
   vim.api.nvim_create_autocmd("WinClosed", {
     pattern = tostring(win),
     once = true,
@@ -492,13 +499,11 @@ function Session:install_cursor_sync()
       local source_line_map = self.content.source_line_map or content_ref.source_line_map
       if source_line_map and last_preview_line <= #source_line_map then
         local target_source_line = source_line_map[last_preview_line]
-        if target_source_line and target_source_line > 0
-          and vim.api.nvim_buf_is_valid(source_bufnr) then
+        if target_source_line and target_source_line > 0 and vim.api.nvim_buf_is_valid(source_bufnr) then
           local total_lines = vim.api.nvim_buf_line_count(source_bufnr)
           target_source_line = math.min(target_source_line, total_lines)
           for _, w in ipairs(vim.api.nvim_list_wins()) do
-            if vim.api.nvim_win_is_valid(w)
-              and vim.api.nvim_win_get_buf(w) == source_bufnr then
+            if vim.api.nvim_win_is_valid(w) and vim.api.nvim_win_get_buf(w) == source_bufnr then
               vim.api.nvim_win_set_cursor(w, { target_source_line, 0 })
               vim.api.nvim_win_call(w, function()
                 vim.cmd "normal! zz"
@@ -522,9 +527,7 @@ end
 local function check_markdown_buffer(bufnr)
   local ft = vim.bo[bufnr].filetype
   local name = vim.api.nvim_buf_get_name(bufnr)
-  if ft == "markdown" or name:match "%.md$" or name:match "%.markdown$" then
-    return true
-  end
+  if ft == "markdown" or name:match "%.md$" or name:match "%.markdown$" then return true end
   return false, "md-render: current buffer is not a Markdown file"
 end
 
@@ -535,9 +538,7 @@ end
 --- Show a floating window previewing the current buffer's markdown content
 ---@param opts? { max_width?: integer }
 MdPreview.show = function(opts)
-  if float_win:close_if_valid() then
-    return
-  end
+  if float_win:close_if_valid() then return end
 
   local bufnr = vim.api.nvim_get_current_buf()
   local ok, warn = check_markdown_buffer(bufnr)
@@ -568,9 +569,7 @@ end
 --- Show a tab previewing the current buffer's markdown content
 ---@param opts? { max_width?: integer }
 MdPreview.show_tab = function(opts)
-  if tab_win:close_if_valid() then
-    return
-  end
+  if tab_win:close_if_valid() then return end
 
   local bufnr = vim.api.nvim_get_current_buf()
   local ok, warn = check_markdown_buffer(bufnr)
@@ -666,8 +665,13 @@ MdPreview.show_pager = function(opts)
     local click_col = mouse.column - 1
 
     local function try_open_url()
-      local extmarks =
-        vim.api.nvim_buf_get_extmarks(session.buf, session.ns, { click_line, 0 }, { click_line + 1, 0 }, { details = true })
+      local extmarks = vim.api.nvim_buf_get_extmarks(
+        session.buf,
+        session.ns,
+        { click_line, 0 },
+        { click_line + 1, 0 },
+        { details = true }
+      )
       for _, mark in ipairs(extmarks) do
         local _, _, start_col, details = unpack(mark)
         if details.url then
@@ -773,9 +777,7 @@ end
 local function restore_render_win_opts(win, saved)
   if not saved then return end
   for _, entry in ipairs(RENDER_WIN_OPTS) do
-    if saved[entry[1]] ~= nil then
-      vim.api.nvim_set_option_value(entry[1], saved[entry[1]], { win = win })
-    end
+    if saved[entry[1]] ~= nil then vim.api.nvim_set_option_value(entry[1], saved[entry[1]], { win = win }) end
   end
 end
 
@@ -832,9 +834,7 @@ local function schedule_live_rebuild(session)
     return
   end
 
-  if session._debounce_timer then
-    session._debounce_timer:stop()
-  end
+  if session._debounce_timer then session._debounce_timer:stop() end
   session._debounce_timer = vim.defer_fn(function()
     session._debounce_timer = nil
     if not vim.api.nvim_buf_is_valid(session.source_bufnr) then return end
@@ -852,19 +852,20 @@ end
 --- Listen for source buffer changes and trigger debounced live rebuilds.
 ---@param session MdRender.Session
 local function install_live_update(session)
-  local augroup = vim.api.nvim_create_augroup(
-    live_update_augroup(session.source_bufnr), { clear = true })
+  local augroup = vim.api.nvim_create_augroup(live_update_augroup(session.source_bufnr), { clear = true })
 
   vim.api.nvim_create_autocmd({
     "TextChanged",
     "TextChangedI",
     "BufWritePost",
-    "BufReadPost",          -- :e reload
+    "BufReadPost", -- :e reload
     "FileChangedShellPost", -- external change detected via :checktime / autoread
   }, {
     group = augroup,
     buffer = session.source_bufnr,
-    callback = function() schedule_live_rebuild(session) end,
+    callback = function()
+      schedule_live_rebuild(session)
+    end,
   })
 end
 
@@ -910,17 +911,14 @@ end
 --- whole cascade without the brittleness of trying to count events.
 ---@param session MdRender.Session
 local function install_scroll_sync(session)
-  local augroup = vim.api.nvim_create_augroup(
-    scroll_sync_augroup(session.source_bufnr), { clear = true })
+  local augroup = vim.api.nvim_create_augroup(scroll_sync_augroup(session.source_bufnr), { clear = true })
 
   local SYNC_UNLOCK_MS = 30
 
   local function with_sync_lock(fn)
     session._syncing = true
     local ok, err = pcall(fn)
-    if session._sync_unlock_timer then
-      session._sync_unlock_timer:stop()
-    end
+    if session._sync_unlock_timer then session._sync_unlock_timer:stop() end
     session._sync_unlock_timer = vim.defer_fn(function()
       session._syncing = false
       session._sync_unlock_timer = nil
@@ -1000,7 +998,16 @@ local function install_scroll_sync(session)
   --- (1 source line ~ many render rows because of images / tables)
   --- can leave the mapped cursor pinned to the bottom edge so a
   --- single `j` flicks it off-screen.
-  local function pick_action(dest_height, dest_lines, mapped_top, mapped_center, mapped_bot_end, src_top_at_edge, src_bot_at_edge, target_cursor)
+  local function pick_action(
+    dest_height,
+    dest_lines,
+    mapped_top,
+    mapped_center,
+    mapped_bot_end,
+    src_top_at_edge,
+    src_bot_at_edge,
+    target_cursor
+  )
     -- Edge snap only when the mapped cursor still fits in the window
     -- from that edge. Otherwise the snap pins topline=1 / botline=last
     -- but the cursor (and shadow) sit beyond the visible rows — common
@@ -1047,7 +1054,7 @@ local function install_scroll_sync(session)
   ---@return integer[] # `{ topline, botline, cursor_line }`
   local function visible_range(win)
     return vim.api.nvim_win_call(win, function()
-      return { vim.fn.line("w0"), vim.fn.line("w$"), vim.fn.line(".") }
+      return { vim.fn.line "w0", vim.fn.line "w$", vim.fn.line "." }
     end)
   end
 
@@ -1067,7 +1074,9 @@ local function install_scroll_sync(session)
     local src_bot_at_edge = source_botline >= source_lines
 
     local render_lines = vim.api.nvim_buf_line_count(session.buf)
-    local function clamp(v) return math.min(math.max(v, 1), render_lines) end
+    local function clamp(v)
+      return math.min(math.max(v, 1), render_lines)
+    end
     local mapped_top = clamp(session:source_to_rendered_f(source_topline))
     local mapped_center = clamp(session:source_to_rendered_f(source_center))
     -- Use the *next* source line's mapped start, then step back one render
@@ -1079,8 +1088,16 @@ local function install_scroll_sync(session)
 
     fan_out(render_wins, source_win, function(w)
       local dest_height = vim.api.nvim_win_get_height(w)
-      return pick_action(dest_height, render_lines, mapped_top, mapped_center, mapped_bot_end,
-        src_top_at_edge, src_bot_at_edge, target_cursor)
+      return pick_action(
+        dest_height,
+        render_lines,
+        mapped_top,
+        mapped_center,
+        mapped_bot_end,
+        src_top_at_edge,
+        src_bot_at_edge,
+        target_cursor
+      )
     end, target_cursor)
   end
 
@@ -1101,7 +1118,9 @@ local function install_scroll_sync(session)
     local src_bot_at_edge = render_botline >= render_lines
 
     local source_lines = vim.api.nvim_buf_line_count(session.source_bufnr)
-    local function clamp(v) return math.min(math.max(v, 1), source_lines) end
+    local function clamp(v)
+      return math.min(math.max(v, 1), source_lines)
+    end
     local mapped_top = clamp(session:rendered_to_source_f(render_topline))
     local mapped_center = clamp(session:rendered_to_source_f(render_center))
     local mapped_bot_end = clamp(session:rendered_to_source_f(render_botline + 1) - 1)
@@ -1110,8 +1129,16 @@ local function install_scroll_sync(session)
 
     fan_out(source_wins, render_win, function(w)
       local dest_height = vim.api.nvim_win_get_height(w)
-      return pick_action(dest_height, source_lines, mapped_top, mapped_center, mapped_bot_end,
-        src_top_at_edge, src_bot_at_edge, target_cursor)
+      return pick_action(
+        dest_height,
+        source_lines,
+        mapped_top,
+        mapped_center,
+        mapped_bot_end,
+        src_top_at_edge,
+        src_bot_at_edge,
+        target_cursor
+      )
     end, target_cursor)
   end
 
@@ -1182,8 +1209,7 @@ end
 --- two sides converge on a fixpoint within one tick.
 ---@param session MdRender.Session
 local function install_shadow_cursor(session)
-  local augroup = vim.api.nvim_create_augroup(
-    shadow_augroup(session.source_bufnr), { clear = true })
+  local augroup = vim.api.nvim_create_augroup(shadow_augroup(session.source_bufnr), { clear = true })
 
   -- Map source line -> [start, end] render line range (inclusive).
   --
@@ -1278,7 +1304,9 @@ local function install_shadow_cursor(session)
     if not vim.api.nvim_buf_is_valid(buf) then return {} end
     local marks = vim.api.nvim_buf_get_extmarks(buf, SHADOW_NS, 0, -1, {})
     local lines = {}
-    for _, m in ipairs(marks) do table.insert(lines, m[2] + 1) end
+    for _, m in ipairs(marks) do
+      table.insert(lines, m[2] + 1)
+    end
     table.sort(lines)
     return lines
   end
@@ -1389,9 +1417,7 @@ local function install_shadow_cursor(session)
       local win = vim.api.nvim_get_current_win()
       if not vim.api.nvim_win_is_valid(win) then return end
       local buf = vim.api.nvim_win_get_buf(win)
-      if buf == session.source_bufnr or buf == session.buf then
-        recompute()
-      end
+      if buf == session.source_bufnr or buf == session.buf then recompute() end
     end,
   })
 
@@ -1422,8 +1448,7 @@ end
 --- new window dimensions.
 ---@param session MdRender.Session
 local function install_win_resize_handler(session)
-  local augroup = vim.api.nvim_create_augroup(
-    win_resize_augroup(session.source_bufnr), { clear = true })
+  local augroup = vim.api.nvim_create_augroup(win_resize_augroup(session.source_bufnr), { clear = true })
 
   vim.api.nvim_create_autocmd("WinResized", {
     group = augroup,
@@ -1475,9 +1500,7 @@ local function install_render_buf_guards(session)
         -- firing BufWriteCmd, so doing so would break our :w forwarding.
       end
       local win = vim.api.nvim_get_current_win()
-      if vim.api.nvim_win_get_buf(win) == session.buf then
-        apply_render_win_opts(win)
-      end
+      if vim.api.nvim_win_get_buf(win) == session.buf then apply_render_win_opts(win) end
 
       -- Mirror the stale-content check from get_or_create_toggle_session
       -- so paths that swap to the render buf without going through
@@ -1507,9 +1530,7 @@ local function install_render_buf_guards(session)
     group = augroup,
     buffer = session.buf,
     callback = function()
-      if vim.api.nvim_buf_is_valid(session.buf) then
-        vim.bo[session.buf].modified = false
-      end
+      if vim.api.nvim_buf_is_valid(session.buf) then vim.bo[session.buf].modified = false end
     end,
   })
 
@@ -1555,9 +1576,7 @@ local function install_render_buf_guards(session)
       vim.o.eventignore = saved_ei
       -- The render buffer's 'modified' flag was set by Vim when :w was
       -- invoked; clear it so the user doesn't see [+] linger.
-      if vim.api.nvim_buf_is_valid(session.buf) then
-        vim.bo[session.buf].modified = false
-      end
+      if vim.api.nvim_buf_is_valid(session.buf) then vim.bo[session.buf].modified = false end
       if not ok then error(err) end
     end,
   })
@@ -1585,9 +1604,7 @@ local function install_source_watcher(session)
         _auto_state[source_bufnr] = nil
       end
       session:cleanup_images()
-      if vim.api.nvim_buf_is_valid(session.buf) then
-        pcall(vim.api.nvim_buf_delete, session.buf, { force = true })
-      end
+      if vim.api.nvim_buf_is_valid(session.buf) then pcall(vim.api.nvim_buf_delete, session.buf, { force = true }) end
       _toggle_sessions[source_bufnr] = nil
       pcall(vim.api.nvim_del_augroup_by_name, toggle_buf_augroup(session.buf))
       pcall(vim.api.nvim_del_augroup_by_name, toggle_src_augroup(source_bufnr))
@@ -1643,9 +1660,7 @@ end
 local function get_win_state(win)
   local ok, state = pcall(vim.api.nvim_win_get_var, win, "md_render_state")
   if not ok or type(state) ~= "table" then return nil end
-  if not state.source_buf or not vim.api.nvim_buf_is_valid(state.source_buf) then
-    return nil
-  end
+  if not state.source_buf or not vim.api.nvim_buf_is_valid(state.source_buf) then return nil end
   return state
 end
 
@@ -1879,8 +1894,7 @@ end
 local function get_auto_target_buf()
   local win = vim.api.nvim_get_current_win()
   local win_state = get_win_state(win)
-  if win_state and win_state.mode == "render"
-    and vim.api.nvim_buf_is_valid(win_state.source_buf) then
+  if win_state and win_state.mode == "render" and vim.api.nvim_buf_is_valid(win_state.source_buf) then
     return win_state.source_buf
   end
   return vim.api.nvim_get_current_buf()
@@ -1906,13 +1920,9 @@ local function schedule_auto_transition(bufnr, target_mode)
     local win_state = get_win_state(win)
 
     if target_mode == "source" then
-      if win_state and win_state.mode == "render" and win_state.source_buf == bufnr then
-        MdPreview.toggle()
-      end
-    else  -- "render"
-      if cur_buf == bufnr and (not win_state or win_state.mode ~= "render") then
-        MdPreview.toggle()
-      end
+      if win_state and win_state.mode == "render" and win_state.source_buf == bufnr then MdPreview.toggle() end
+    else -- "render"
+      if cur_buf == bufnr and (not win_state or win_state.mode ~= "render") then MdPreview.toggle() end
     end
   end, 50)
 end
@@ -1938,20 +1948,18 @@ function MdPreview.auto_on(opts)
   vim.api.nvim_create_autocmd("InsertLeave", {
     group = augroup,
     buffer = bufnr,
-    callback = function() schedule_auto_transition(bufnr, "render") end,
+    callback = function()
+      schedule_auto_transition(bufnr, "render")
+    end,
   })
 
   local win = vim.api.nvim_get_current_win()
   local win_state = get_win_state(win)
-  if not win_state or win_state.mode ~= "render" then
-    MdPreview.toggle(opts)
-  end
+  if not win_state or win_state.mode ~= "render" then MdPreview.toggle(opts) end
 
   -- Install Insert-entry keymaps on the render buffer (now created by toggle).
   local session = _toggle_sessions[bufnr]
-  if session and vim.api.nvim_buf_is_valid(session.buf) then
-    install_auto_insert_keymaps(session.buf)
-  end
+  if session and vim.api.nvim_buf_is_valid(session.buf) then install_auto_insert_keymaps(session.buf) end
 end
 
 --- Disable auto-toggle for the current buffer and, if the current window is
@@ -1975,9 +1983,7 @@ function MdPreview.auto_off()
 
   local win = vim.api.nvim_get_current_win()
   local win_state = get_win_state(win)
-  if win_state and win_state.mode == "render" and win_state.source_buf == bufnr then
-    MdPreview.toggle()
-  end
+  if win_state and win_state.mode == "render" and win_state.source_buf == bufnr then MdPreview.toggle() end
 end
 
 --- Flip auto-toggle state for the current buffer.
@@ -2009,148 +2015,159 @@ MdPreview.show_demo = function()
   local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h:h")
   local demo_img_dir = plugin_root .. "/assets/demo"
 
-  local demo_lines = vim.split(table.concat({
-    "## Markdown Rendering Features",
-    "",
-    "**Bold**, ~~strikethrough~~, `inline code`, and [links](https://neovim.io) — all rendered inline. Bare URLs like https://neovim.io stay clickable. Long ones like https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L123-L456 are truncated. Obsidian ==highlight== and `%%comments%%` also work.",
-    "",
-    "### Code & Tables",
-    "",
-    "```lua",
-    'local function greet(name) return "Hello, " .. name end',
-    "-- This line is intentionally long to demonstrate that code lines exceeding the max width are truncated with an ellipsis indicator",
-    "```",
-    "",
-    "| Feature | Description | Syntax |",
-    "|---------|-------------|--------|",
-    "| **Bold** / ~~strike~~ | Inline formatting is rendered inside table cells | `**text**` / `~~text~~` |",
-    "| Truncation | Cells that exceed the available width are automatically truncated with an ellipsis | Long content is gracefully handled |",
-    "",
-    "### Lists",
-    "",
-    "- First item",
-    "- Second item with **bold** and `code`",
-    "  - Nested item",
-    "  - Another nested",
-    "    - Deeply nested",
-    "      - Back to level 0 style",
-    "- Back to top level",
-    "",
-    "1. Ordered first",
-    "2. Ordered second",
-    "  1. Nested ordered",
-    "  2. Nested second",
-    "3. Back to top",
-    "",
-    "- [ ] Unchecked task",
-    "- [x] Completed task",
-    "- [-] In-progress task",
-    "",
-    "### Callouts & Folds",
-    "",
-    "> [!NOTE]",
-    "> Standard callout. Five types: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`.",
-    "",
-    "> [!TIP]- Foldable (collapsed)",
-    "> Hidden until you click the header. Supports **multiple lines**.",
-    "> Click the fold indicator to toggle.",
-    "",
-    "> [!WARNING]+ Foldable (expanded)",
-    "> Visible by default, click to collapse.",
-    "> ```lua",
-    "> local msg = 'Code blocks inside callouts get treesitter highlighting!'",
-    "> ```",
-    "",
-    "> [!custom] Custom types work too",
-    "> Any `[!type]` is rendered as a callout.",
-    "> - Lists inside callouts",
-    "> - Also get bullet symbols",
-    ">   - Including nested ones",
-    "> 1. Ordered lists too",
-    "> 2. Work just fine",
-    "",
-    "### Expandable Content",
-    "",
-    "```bash",
-    "# This line is intentionally very long to demonstrate the expandable code block feature — click the underlined … to see the full content and scroll horizontally",
-    "echo 'Click the … on truncated lines to expand, click again to collapse'",
-    "```",
-    "",
-    "### Collapsible Details",
-    "",
-    "<details>",
-    "<summary>Click to expand this section</summary>",
-    "",
-    "This content is hidden by default. It supports **bold**, `code`, and [links](https://neovim.io).",
-    "",
-    "</details>",
-    "",
-    "<details open>",
-    "<summary>Open by default</summary>",
-    "",
-    "The `open` attribute makes it expanded initially. Click to collapse.",
-    "",
-    "</details>",
-    "",
-    "### 日本語テキストの折り返し",
-    "",
-    "budoux.luaがインストールされていれば、BudouXによる自然な分節処理で日本語テキストを文節の区切りで改行します。未インストールの場合は1文字ずつ分割して折り返します。",
-    "",
-    "句読点「、」や閉じ括弧「)」が行頭に来ないよう禁則処理(JIS X 4051)を適用。開き括弧「(」は行末に残さず次の行へ送ります。",
-    "",
-    "> [!NOTE] 日本語コールアウト",
-    "> コールアウト内でも禁則処理は有効。budoux.luaがあればBudouXの分節処理も適用され、長い文章を自然な位置で折り返します。",
-    "",
-    "### Qiita Extensions",
-    "",
-    "```ruby:app/models/user.rb",
-    "class User < ApplicationRecord",
-    "  validates :name, presence: true",
-    "end",
-    "```",
-    "",
-    ":::note info",
-    "Qiitaのノート記法(info)です。`:::note info` で始まり `:::` で閉じます。",
-    ":::",
-    "",
-    ":::note warn",
-    "警告メッセージを表示できます。",
-    ":::",
-    "",
-    ":::note alert",
-    "重要な注意事項を強調できます。",
-    ":::",
-    "",
-    "### Images",
-    "",
-    "| PNG | JPEG | WebP | GIF | Animated GIF |",
-    "|-----|------|------|-----|--------------|",
-    "| ![PNG](" .. demo_img_dir .. "/test.png) | ![JPEG](" .. demo_img_dir .. "/test.jpg) | ![WebP](" .. demo_img_dir .. "/test.webp) | ![GIF](" .. demo_img_dir .. "/test.gif) | ![Animated GIF](" .. demo_img_dir .. "/test_animated.gif) |",
-    "",
-    "### Web Images",
-    "",
-    "| Static (http.cat) | Animated GIF (Nyan Cat) |",
-    "|--------------------|-----------------------|",
-    "| ![HTTP 200](https://http.cat/200.jpg) | ![Nyan Cat](https://media.giphy.com/media/sIIhZliB2McAo/giphy.gif) |",
-    "",
-    "### Video",
-    "",
-    '<video src="' .. demo_img_dir .. '/test.mp4" controls></video>',
-    "",
-    "### Mermaid Diagram",
-    "",
-    "```mermaid",
-    "graph LR",
-    "    A[Markdown] --> B[Parser]",
-    "    B --> C[ContentBuilder]",
-    "    C --> D[FloatWin]",
-    "    D --> E[Display]",
-    "```",
-  }, "\n"), "\n")
+  local demo_lines = vim.split(
+    table.concat({
+      "## Markdown Rendering Features",
+      "",
+      "**Bold**, ~~strikethrough~~, `inline code`, and [links](https://neovim.io) — all rendered inline. Bare URLs like https://neovim.io stay clickable. Long ones like https://github.com/neovim/neovim/blob/master/src/nvim/api/buffer.c#L123-L456 are truncated. Obsidian ==highlight== and `%%comments%%` also work.",
+      "",
+      "### Code & Tables",
+      "",
+      "```lua",
+      'local function greet(name) return "Hello, " .. name end',
+      "-- This line is intentionally long to demonstrate that code lines exceeding the max width are truncated with an ellipsis indicator",
+      "```",
+      "",
+      "| Feature | Description | Syntax |",
+      "|---------|-------------|--------|",
+      "| **Bold** / ~~strike~~ | Inline formatting is rendered inside table cells | `**text**` / `~~text~~` |",
+      "| Truncation | Cells that exceed the available width are automatically truncated with an ellipsis | Long content is gracefully handled |",
+      "",
+      "### Lists",
+      "",
+      "- First item",
+      "- Second item with **bold** and `code`",
+      "  - Nested item",
+      "  - Another nested",
+      "    - Deeply nested",
+      "      - Back to level 0 style",
+      "- Back to top level",
+      "",
+      "1. Ordered first",
+      "2. Ordered second",
+      "  1. Nested ordered",
+      "  2. Nested second",
+      "3. Back to top",
+      "",
+      "- [ ] Unchecked task",
+      "- [x] Completed task",
+      "- [-] In-progress task",
+      "",
+      "### Callouts & Folds",
+      "",
+      "> [!NOTE]",
+      "> Standard callout. Five types: `NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`.",
+      "",
+      "> [!TIP]- Foldable (collapsed)",
+      "> Hidden until you click the header. Supports **multiple lines**.",
+      "> Click the fold indicator to toggle.",
+      "",
+      "> [!WARNING]+ Foldable (expanded)",
+      "> Visible by default, click to collapse.",
+      "> ```lua",
+      "> local msg = 'Code blocks inside callouts get treesitter highlighting!'",
+      "> ```",
+      "",
+      "> [!custom] Custom types work too",
+      "> Any `[!type]` is rendered as a callout.",
+      "> - Lists inside callouts",
+      "> - Also get bullet symbols",
+      ">   - Including nested ones",
+      "> 1. Ordered lists too",
+      "> 2. Work just fine",
+      "",
+      "### Expandable Content",
+      "",
+      "```bash",
+      "# This line is intentionally very long to demonstrate the expandable code block feature — click the underlined … to see the full content and scroll horizontally",
+      "echo 'Click the … on truncated lines to expand, click again to collapse'",
+      "```",
+      "",
+      "### Collapsible Details",
+      "",
+      "<details>",
+      "<summary>Click to expand this section</summary>",
+      "",
+      "This content is hidden by default. It supports **bold**, `code`, and [links](https://neovim.io).",
+      "",
+      "</details>",
+      "",
+      "<details open>",
+      "<summary>Open by default</summary>",
+      "",
+      "The `open` attribute makes it expanded initially. Click to collapse.",
+      "",
+      "</details>",
+      "",
+      "### 日本語テキストの折り返し",
+      "",
+      "budoux.luaがインストールされていれば、BudouXによる自然な分節処理で日本語テキストを文節の区切りで改行します。未インストールの場合は1文字ずつ分割して折り返します。",
+      "",
+      "句読点「、」や閉じ括弧「)」が行頭に来ないよう禁則処理(JIS X 4051)を適用。開き括弧「(」は行末に残さず次の行へ送ります。",
+      "",
+      "> [!NOTE] 日本語コールアウト",
+      "> コールアウト内でも禁則処理は有効。budoux.luaがあればBudouXの分節処理も適用され、長い文章を自然な位置で折り返します。",
+      "",
+      "### Qiita Extensions",
+      "",
+      "```ruby:app/models/user.rb",
+      "class User < ApplicationRecord",
+      "  validates :name, presence: true",
+      "end",
+      "```",
+      "",
+      ":::note info",
+      "Qiitaのノート記法(info)です。`:::note info` で始まり `:::` で閉じます。",
+      ":::",
+      "",
+      ":::note warn",
+      "警告メッセージを表示できます。",
+      ":::",
+      "",
+      ":::note alert",
+      "重要な注意事項を強調できます。",
+      ":::",
+      "",
+      "### Images",
+      "",
+      "| PNG | JPEG | WebP | GIF | Animated GIF |",
+      "|-----|------|------|-----|--------------|",
+      "| ![PNG]("
+        .. demo_img_dir
+        .. "/test.png) | ![JPEG]("
+        .. demo_img_dir
+        .. "/test.jpg) | ![WebP]("
+        .. demo_img_dir
+        .. "/test.webp) | ![GIF]("
+        .. demo_img_dir
+        .. "/test.gif) | ![Animated GIF]("
+        .. demo_img_dir
+        .. "/test_animated.gif) |",
+      "",
+      "### Web Images",
+      "",
+      "| Static (http.cat) | Animated GIF (Nyan Cat) |",
+      "|--------------------|-----------------------|",
+      "| ![HTTP 200](https://http.cat/200.jpg) | ![Nyan Cat](https://media.giphy.com/media/sIIhZliB2McAo/giphy.gif) |",
+      "",
+      "### Video",
+      "",
+      '<video src="' .. demo_img_dir .. '/test.mp4" controls></video>',
+      "",
+      "### Mermaid Diagram",
+      "",
+      "```mermaid",
+      "graph LR",
+      "    A[Markdown] --> B[Parser]",
+      "    B --> C[ContentBuilder]",
+      "    C --> D[FloatWin]",
+      "    D --> E[Display]",
+      "```",
+    }, "\n"),
+    "\n"
+  )
 
-  if demo_float_win:close_if_valid() then
-    return
-  end
+  if demo_float_win:close_if_valid() then return end
 
   local fold_state = {}
   local expand_state = {}
@@ -2178,7 +2195,10 @@ MdPreview.show_demo = function()
     vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
     local any_expanded = false
     for _, v in pairs(expand_state) do
-      if v then any_expanded = true; break end
+      if v then
+        any_expanded = true
+        break
+      end
     end
     vim.api.nvim_set_option_value("wrap", not any_expanded, { win = win })
     content = new_content

--- a/lua/md-render/snacks.lua
+++ b/lua/md-render/snacks.lua
@@ -27,9 +27,7 @@ local function build_image_content(filepath, winid)
 
   local filename = filepath:match "([^/]+)$" or filepath
   local header = "  " .. filename
-  if img_w and img_h then
-    header = header .. "  (" .. img_w .. "×" .. img_h .. ")"
-  end
+  if img_w and img_h then header = header .. "  (" .. img_w .. "×" .. img_h .. ")" end
 
   local lines = { header }
   for _ = 1, rows do
@@ -40,16 +38,18 @@ local function build_image_content(filepath, winid)
     lines = lines,
     highlights = { { line = 0, groups = { { col = 0, end_col = #header, hl = "Comment" } } } },
     link_metadata = {},
-    image_placements = { {
-      path = filepath,
-      line = 1,
-      col = math.max(0, math.floor((win_width - cols) / 2)),
-      rows = rows,
-      cols = cols,
-      img_w = img_w,
-      img_h = img_h,
-      video = is_video,
-    } },
+    image_placements = {
+      {
+        path = filepath,
+        line = 1,
+        col = math.max(0, math.floor((win_width - cols) / 2)),
+        rows = rows,
+        cols = cols,
+        img_w = img_w,
+        img_h = img_h,
+        video = is_video,
+      },
+    },
   }
 end
 

--- a/lua/md-render/telescope.lua
+++ b/lua/md-render/telescope.lua
@@ -27,9 +27,7 @@ local function build_image_content(filepath, winid)
 
   local filename = filepath:match "([^/]+)$" or filepath
   local header = "  " .. filename
-  if img_w and img_h then
-    header = header .. "  (" .. img_w .. "×" .. img_h .. ")"
-  end
+  if img_w and img_h then header = header .. "  (" .. img_w .. "×" .. img_h .. ")" end
 
   local lines = { header }
   for _ = 1, rows do
@@ -40,16 +38,18 @@ local function build_image_content(filepath, winid)
     lines = lines,
     highlights = { { line = 0, groups = { { col = 0, end_col = #header, hl = "Comment" } } } },
     link_metadata = {},
-    image_placements = { {
-      path = filepath,
-      line = 1,
-      col = math.max(0, math.floor((win_width - cols) / 2)),
-      rows = rows,
-      cols = cols,
-      img_w = img_w,
-      img_h = img_h,
-      video = is_video,
-    } },
+    image_placements = {
+      {
+        path = filepath,
+        line = 1,
+        col = math.max(0, math.floor((win_width - cols) / 2)),
+        rows = rows,
+        cols = cols,
+        img_w = img_w,
+        img_h = img_h,
+        video = is_video,
+      },
+    },
   }
 end
 

--- a/lua/md-render/tty.lua
+++ b/lua/md-render/tty.lua
@@ -79,12 +79,12 @@ end
 -- Platform constants
 -- ============================================================================
 
-local SOL_LOCAL = 0          -- macOS: level for local socket options
-local LOCAL_PEERPID = 0x002  -- macOS: retrieve peer pid
-local SOL_SOCKET_LINUX = 1   -- Linux: SOL_SOCKET
-local SO_PEERCRED = 17       -- Linux: retrieve peer credentials
-local PROC_PIDTBSDINFO = 3   -- macOS: proc_pidinfo flavor
-local S_IFCHR = 0x2000       -- character device mode
+local SOL_LOCAL = 0 -- macOS: level for local socket options
+local LOCAL_PEERPID = 0x002 -- macOS: retrieve peer pid
+local SOL_SOCKET_LINUX = 1 -- Linux: SOL_SOCKET
+local SO_PEERCRED = 17 -- Linux: retrieve peer credentials
+local PROC_PIDTBSDINFO = 3 -- macOS: proc_pidinfo flavor
+local S_IFCHR = 0x2000 -- character device mode
 
 -- ============================================================================
 -- Level 1: Direct TTY detection via isatty() + ttyname()
@@ -96,12 +96,10 @@ function M._detect_direct()
   if IS_WINDOWS then return nil end
   ensure_ffi()
   -- Try stderr first (most likely to survive redirects), then stdout, stdin
-  for _, fd in ipairs({ 2, 1, 0 }) do
+  for _, fd in ipairs { 2, 1, 0 } do
     if ffi.C.isatty(fd) ~= 0 then
       local name = ffi.C.ttyname(fd)
-      if name ~= nil then
-        return ffi.string(name)
-      end
+      if name ~= nil then return ffi.string(name) end
     end
   end
   return nil
@@ -134,15 +132,15 @@ local function get_socket_peer_pid(fd)
   if IS_WINDOWS then return nil end
   ensure_ffi()
   if IS_OSX then
-    local pid = ffi.new("int[1]")
-    local len = ffi.new("unsigned int[1]", ffi.sizeof("int"))
+    local pid = ffi.new "int[1]"
+    local len = ffi.new("unsigned int[1]", ffi.sizeof "int")
     if ffi.C.getsockopt(fd, SOL_LOCAL, LOCAL_PEERPID, pid, len) == 0 then
       local p = pid[0]
       if p > 1 then return p end
     end
   elseif IS_LINUX then
-    local cred = ffi.new("struct md_ucred")
-    local len = ffi.new("unsigned int[1]", ffi.sizeof("struct md_ucred"))
+    local cred = ffi.new "struct md_ucred"
+    local len = ffi.new("unsigned int[1]", ffi.sizeof "struct md_ucred")
     if ffi.C.getsockopt(fd, SOL_SOCKET_LINUX, SO_PEERCRED, cred, len) == 0 then
       local p = cred.pid
       if p > 1 then return p end
@@ -157,7 +155,7 @@ M._get_socket_peer_pid = get_socket_peer_pid -- expose for testing
 ---@return string?
 local function get_pid_tty_darwin(pid)
   ensure_ffi()
-  local info = ffi.new("struct md_proc_bsdinfo")
+  local info = ffi.new "struct md_proc_bsdinfo"
   local size = ffi.C.proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, info, ffi.sizeof(info))
   if size <= 0 then return nil end
   local dev = info.e_tdev
@@ -175,14 +173,14 @@ M._get_pid_tty_darwin = get_pid_tty_darwin
 local function get_pid_tty_linux(pid)
   local f = io.open("/proc/" .. pid .. "/stat", "r")
   if not f then return nil end
-  local content = f:read("*a")
+  local content = f:read "*a"
   f:close()
   -- Format: pid (comm) state ppid pgrp session tty_nr ...
   -- comm can contain spaces/parens, so find the LAST ")"
-  local after_comm = content:match("^.*%)%s+(.*)")
+  local after_comm = content:match "^.*%)%s+(.*)"
   if not after_comm then return nil end
   local fields = {}
-  for field in after_comm:gmatch("%S+") do
+  for field in after_comm:gmatch "%S+" do
     table.insert(fields, field)
     if #fields >= 5 then break end
   end
@@ -192,9 +190,7 @@ local function get_pid_tty_linux(pid)
   local major = bit.band(bit.rshift(tty_nr, 8), 0xFF)
   local minor = bit.bor(bit.band(tty_nr, 0xFF), bit.band(bit.rshift(tty_nr, 12), 0xFFF00))
   -- pts devices have major 136
-  if major == 136 then
-    return "/dev/pts/" .. minor
-  end
+  if major == 136 then return "/dev/pts/" .. minor end
   -- Other TTY types: try /dev/ttyN
   return "/dev/tty" .. minor
 end
@@ -246,9 +242,7 @@ end
 function M.get_tty_path()
   if _tty_detected then return _tty_path end
   _tty_detected = true
-  _tty_path = M._detect_direct()
-    or M._detect_dev_tty()
-    or M._detect_socket_peer()
+  _tty_path = M._detect_direct() or M._detect_dev_tty() or M._detect_socket_peer()
   return _tty_path
 end
 

--- a/lua/md-render/url_hover.lua
+++ b/lua/md-render/url_hover.lua
@@ -28,9 +28,7 @@ local state = {
 local augroup_initialized = false
 
 local function ensure_hover_buf()
-  if state.hover_buf and vim.api.nvim_buf_is_valid(state.hover_buf) then
-    return state.hover_buf
-  end
+  if state.hover_buf and vim.api.nvim_buf_is_valid(state.hover_buf) then return state.hover_buf end
   state.hover_buf = vim.api.nvim_create_buf(false, true)
   vim.bo[state.hover_buf].bufhidden = "hide"
   return state.hover_buf
@@ -89,9 +87,7 @@ end
 ---@param url string
 ---@param source_win integer
 local function show_hover(url, source_win)
-  if state.current_url == url and state.current_win == source_win then
-    return
-  end
+  if state.current_url == url and state.current_win == source_win then return end
 
   local max_width = math.max(1, math.floor(vim.o.columns / 2))
   local display = truncate_url(url, max_width)
@@ -145,19 +141,14 @@ local function url_at_mouse(mouse, buf, ns)
   local line_count = vim.api.nvim_buf_line_count(buf)
   if line >= line_count then return nil end
 
-  local ok, marks = pcall(
-    vim.api.nvim_buf_get_extmarks,
-    buf, ns, { line, 0 }, { line + 1, 0 }, { details = true }
-  )
+  local ok, marks = pcall(vim.api.nvim_buf_get_extmarks, buf, ns, { line, 0 }, { line + 1, 0 }, { details = true })
   if not ok then return nil end
 
   for _, mark in ipairs(marks) do
     local _, _, start_col, details = unpack(mark)
     if details and details.url then
       local end_col = details.end_col or (start_col + 1)
-      if col >= start_col and col < end_col then
-        return details.url
-      end
+      if col >= start_col and col < end_col then return details.url end
     end
   end
   return nil
@@ -228,9 +219,7 @@ function M.attach(buf, ns, win)
     callback = function()
       registered[win] = nil
       cancel_pending()
-      if state.current_win == win then
-        close_hover()
-      end
+      if state.current_win == win then close_hover() end
     end,
   })
 end

--- a/lua/md-render/wrap.lua
+++ b/lua/md-render/wrap.lua
@@ -9,29 +9,113 @@ local M = {}
 local NO_BREAK_START = {}
 for _, ch in ipairs {
   -- Cl.02 終わり括弧類
-  "）", "〕", "］", "｝", "〉", "》", "」", "』", "】", "｠", "〙", "〗", "»",
+  "）",
+  "〕",
+  "］",
+  "｝",
+  "〉",
+  "》",
+  "」",
+  "』",
+  "】",
+  "｠",
+  "〙",
+  "〗",
+  "»",
   -- Cl.03 ハイフン類
-  "‐", "〜",
+  "‐",
+  "〜",
   -- Cl.04 区切り約物
-  "！", "？", "‼", "⁇", "⁈", "⁉",
+  "！",
+  "？",
+  "‼",
+  "⁇",
+  "⁈",
+  "⁉",
   -- Cl.05 中点類
-  "・", "：", "；",
+  "・",
+  "：",
+  "；",
   -- Cl.06 句点類
-  "。", "．",
+  "。",
+  "．",
   -- Cl.07 読点類
-  "、", "，",
+  "、",
+  "，",
   -- Cl.08 繰返し記号
-  "ゝ", "ゞ", "ヽ", "ヾ", "々", "〻",
+  "ゝ",
+  "ゞ",
+  "ヽ",
+  "ヾ",
+  "々",
+  "〻",
   -- Cl.09 長音記号
   "ー",
   -- Cl.10 小書きの仮名
-  "ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "っ", "ゃ", "ゅ", "ょ", "ゎ", "ゕ", "ゖ",
-  "ァ", "ィ", "ゥ", "ェ", "ォ", "ッ", "ャ", "ュ", "ョ", "ヮ", "ヵ", "ヶ",
-  "ㇰ", "ㇱ", "ㇲ", "ㇳ", "ㇴ", "ㇵ", "ㇶ", "ㇷ", "ㇸ", "ㇹ", "ㇺ", "ㇻ", "ㇼ", "ㇽ", "ㇾ", "ㇿ",
+  "ぁ",
+  "ぃ",
+  "ぅ",
+  "ぇ",
+  "ぉ",
+  "っ",
+  "ゃ",
+  "ゅ",
+  "ょ",
+  "ゎ",
+  "ゕ",
+  "ゖ",
+  "ァ",
+  "ィ",
+  "ゥ",
+  "ェ",
+  "ォ",
+  "ッ",
+  "ャ",
+  "ュ",
+  "ョ",
+  "ヮ",
+  "ヵ",
+  "ヶ",
+  "ㇰ",
+  "ㇱ",
+  "ㇲ",
+  "ㇳ",
+  "ㇴ",
+  "ㇵ",
+  "ㇶ",
+  "ㇷ",
+  "ㇸ",
+  "ㇹ",
+  "ㇺ",
+  "ㇻ",
+  "ㇼ",
+  "ㇽ",
+  "ㇾ",
+  "ㇿ",
   -- 半角カタカナ
-  "｡", "､", "｣", "ｧ", "ｨ", "ｩ", "ｪ", "ｫ", "ｯ", "ｬ", "ｭ", "ｮ", "ｰ",
+  "｡",
+  "､",
+  "｣",
+  "ｧ",
+  "ｨ",
+  "ｩ",
+  "ｪ",
+  "ｫ",
+  "ｯ",
+  "ｬ",
+  "ｭ",
+  "ｮ",
+  "ｰ",
   -- ASCII (half-width) punctuation
-  ")", "]", "}", "!", "?", ",", ".", ";", ":",
+  ")",
+  "]",
+  "}",
+  "!",
+  "?",
+  ",",
+  ".",
+  ";",
+  ":",
 } do
   NO_BREAK_START[ch] = true
 end
@@ -41,11 +125,25 @@ end
 local NO_BREAK_END = {}
 for _, ch in ipairs {
   -- Cl.01 始め括弧類
-  "（", "〔", "［", "｛", "〈", "《", "「", "『", "【", "｟", "〘", "〖", "«",
+  "（",
+  "〔",
+  "［",
+  "｛",
+  "〈",
+  "《",
+  "「",
+  "『",
+  "【",
+  "｟",
+  "〘",
+  "〖",
+  "«",
   -- 半角カタカナ
   "｢",
   -- ASCII (half-width) punctuation
-  "(", "[", "{",
+  "(",
+  "[",
+  "{",
 } do
   NO_BREAK_END[ch] = true
 end
@@ -118,9 +216,7 @@ local budoux_model = budoux_parser and budoux_parser.model or nil
 ---@param min_chars? integer Minimum characters per segment (default 4)
 ---@return string[] chunks
 local function split_katakana_compound(text, min_chars)
-  if not budoux_model then
-    return { text }
-  end
+  if not budoux_model then return { text } end
   min_chars = min_chars or 4
 
   local INVALID = "\xef\xbf\xbd"
@@ -128,9 +224,7 @@ local function split_katakana_compound(text, min_chars)
   for c in text:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
     chars[#chars + 1] = c
   end
-  if #chars <= min_chars * 2 then
-    return { text }
-  end
+  if #chars <= min_chars * 2 then return { text } end
 
   -- Score bonus for boundaries after "ン" (moraic nasal).
   -- "ン" almost always ends a morpheme in katakana loanwords, making it
@@ -141,10 +235,26 @@ local function split_katakana_compound(text, min_chars)
   local moraic_n_bonus = math.floor(budoux_model.base_score * 0.4)
   local dakuten = {}
   for _, ch in ipairs {
-    "ガ", "ギ", "グ", "ゲ", "ゴ",
-    "ザ", "ジ", "ズ", "ゼ", "ゾ",
-    "ダ", "ヂ", "ヅ", "デ", "ド",
-    "バ", "ビ", "ブ", "ベ", "ボ",
+    "ガ",
+    "ギ",
+    "グ",
+    "ゲ",
+    "ゴ",
+    "ザ",
+    "ジ",
+    "ズ",
+    "ゼ",
+    "ゾ",
+    "ダ",
+    "ヂ",
+    "ヅ",
+    "デ",
+    "ド",
+    "バ",
+    "ビ",
+    "ブ",
+    "ベ",
+    "ボ",
   } do
     dakuten[ch] = true
   end
@@ -175,18 +285,14 @@ local function split_katakana_compound(text, min_chars)
     if budoux_model.TW4 then score = score + (budoux_model.TW4[w1 .. w2 .. w3] or 0) end
 
     -- Boost score for boundaries after "ン", unless followed by voiced consonant
-    if p3 == "ン" and not dakuten[w1] then
-      score = score + moraic_n_bonus
-    end
+    if p3 == "ン" and not dakuten[w1] then score = score + moraic_n_bonus end
 
     -- Penalty for splitting right after ッ + consonant kana.
     -- "ッ" (geminate) bonds tightly with the following kana, and the next
     -- character often continues the same morpheme (e.g. シンタック|ス is wrong;
     -- シンタックス|ハイライト is correct).  Strong boundaries like
     -- コードブロック|ヘッダ still pass because their base score is high enough.
-    if i >= 3 and chars[i - 2] == "ッ" then
-      score = score - math.floor(budoux_model.base_score * 0.35)
-    end
+    if i >= 3 and chars[i - 2] == "ッ" then score = score - math.floor(budoux_model.base_score * 0.35) end
 
     boundary_scores[i] = score
   end
@@ -206,12 +312,19 @@ local function split_katakana_compound(text, min_chars)
   for i = 2, #chars do
     local w1 = chars[i]
     -- Don't split before small kana, ー, ッ, ン (these attach to preceding char)
-    if not NO_BREAK_START[w1] and w1 ~= "ッ" and w1 ~= "ン" and w1 ~= "ー"
-        and boundary_scores[i] > score_threshold then
+    if
+      not NO_BREAK_START[w1]
+      and w1 ~= "ッ"
+      and w1 ~= "ン"
+      and w1 ~= "ー"
+      and boundary_scores[i] > score_threshold
+    then
       candidates[#candidates + 1] = { pos = i, score = boundary_scores[i] }
     end
   end
-  table.sort(candidates, function(a, b) return a.score > b.score end)
+  table.sort(candidates, function(a, b)
+    return a.score > b.score
+  end)
 
   -- Greedily select split positions (highest score first) that maintain min_chars
   local selected = {}
@@ -235,9 +348,7 @@ local function split_katakana_compound(text, min_chars)
         break
       end
     end
-    if ok then
-      selected[#selected + 1] = cand.pos
-    end
+    if ok then selected[#selected + 1] = cand.pos end
   end
   table.sort(selected)
 
@@ -323,9 +434,7 @@ local function split_by_script(chunk)
   for i = 2, #chars do
     local cls = script_class(chars[i])
     local should_split = false
-    if chars[i - 1] == "・" and current ~= "・" then
-      should_split = true
-    end
+    if chars[i - 1] == "・" and current ~= "・" then should_split = true end
     if cls ~= "O" and cls ~= prev_cls then
       if prev_cls == "K" then
         should_split = true
@@ -356,9 +465,7 @@ end
 ---@return boolean
 local function is_katakana_only(s)
   for c in s:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
-    if script_class(c) ~= "K" then
-      return false
-    end
+    if script_class(c) ~= "K" then return false end
   end
   return true
 end
@@ -409,10 +516,16 @@ end
 
 --- Vowel lookup for English syllable-like word splitting.
 local ascii_vowels = {
-  [string.byte "a"] = true, [string.byte "e"] = true, [string.byte "i"] = true,
-  [string.byte "o"] = true, [string.byte "u"] = true,
-  [string.byte "A"] = true, [string.byte "E"] = true, [string.byte "I"] = true,
-  [string.byte "O"] = true, [string.byte "U"] = true,
+  [string.byte "a"] = true,
+  [string.byte "e"] = true,
+  [string.byte "i"] = true,
+  [string.byte "o"] = true,
+  [string.byte "u"] = true,
+  [string.byte "A"] = true,
+  [string.byte "E"] = true,
+  [string.byte "I"] = true,
+  [string.byte "O"] = true,
+  [string.byte "U"] = true,
 }
 
 --- Split a long ASCII word into syllable-like segments at vowel→consonant
@@ -437,9 +550,14 @@ local function split_ascii_syllables(word, word_start, leading_space)
     local b_next = word:byte(i + 1)
     -- Break after a vowel when followed by an alphabetic consonant,
     -- ensuring at least 2 chars remain on each side
-    if ascii_vowels[b] and b_next and not ascii_vowels[b_next]
-        and ((b_next >= 65 and b_next <= 90) or (b_next >= 97 and b_next <= 122))
-        and i - seg_start >= 1 and #word - i >= 2 then
+    if
+      ascii_vowels[b]
+      and b_next
+      and not ascii_vowels[b_next]
+      and ((b_next >= 65 and b_next <= 90) or (b_next >= 97 and b_next <= 122))
+      and i - seg_start >= 1
+      and #word - i >= 2
+    then
       table.insert(result, {
         text = word:sub(seg_start, i),
         byte_pos = word_start + seg_start - 1,
@@ -477,7 +595,10 @@ local function split_segments(text)
 
   local function flush_ascii()
     if current_word ~= "" then
-      table.insert(segments, { text = current_word, byte_pos = current_word_start, has_leading_space = has_leading_space })
+      table.insert(
+        segments,
+        { text = current_word, byte_pos = current_word_start, has_leading_space = has_leading_space }
+      )
       current_word = ""
       has_leading_space = false
     end
@@ -554,9 +675,7 @@ local function split_segments(text)
     else
       -- ASCII/narrow character: accumulate into word
       flush_cjk()
-      if current_word == "" then
-        current_word_start = byte_pos
-      end
+      if current_word == "" then current_word_start = byte_pos end
       current_word = current_word .. char
       -- Allow line breaking after hyphens in compound words (e.g. "mission-code-job")
       -- and after path/query separators in URLs and paths
@@ -564,8 +683,11 @@ local function split_segments(text)
       -- word (including the separator) as a segment. Without this, long URLs in
       -- inline code spans become a single unbreakable token and force the float
       -- window to widen.
-      if (char == "-" or char == "/" or char == "?" or char == "&")
-          and #current_word > 1 and current_word:sub(-2, -2):match "[%w]" then
+      if
+        (char == "-" or char == "/" or char == "?" or char == "&")
+        and #current_word > 1
+        and current_word:sub(-2, -2):match "[%w]"
+      then
         flush_ascii()
       end
     end
@@ -608,9 +730,7 @@ function M.wrap_words(text, max_width)
     if s == "" then return false end
     local lc = last_char(s)
     if NO_BREAK_END[lc] then return true end
-    if AMBIGUOUS_QUOTE[lc] and quote_roles[byte_start + #s - #lc] == "open" then
-      return true
-    end
+    if AMBIGUOUS_QUOTE[lc] and quote_roles[byte_start + #s - #lc] == "open" then return true end
     return false
   end
 

--- a/lua/telescope/_extensions/md_render.lua
+++ b/lua/telescope/_extensions/md_render.lua
@@ -10,9 +10,7 @@
 local previewer_cache = nil
 
 local function get_previewer()
-  if not previewer_cache then
-    previewer_cache = require("md-render.telescope").previewer()
-  end
+  if not previewer_cache then previewer_cache = require("md-render.telescope").previewer() end
   return previewer_cache
 end
 

--- a/plugin/md-render.lua
+++ b/plugin/md-render.lua
@@ -1,6 +1,4 @@
-if vim.g.loaded_md_render then
-  return
-end
+if vim.g.loaded_md_render then return end
 vim.g.loaded_md_render = true
 
 vim.keymap.set("n", "<Plug>(md-render-preview)", function()

--- a/tests/command_test.lua
+++ b/tests/command_test.lua
@@ -45,15 +45,15 @@ local function with_preview_stub()
     end
   end
   local stub_preview = {
-    show = rec("show"),
-    show_tab = rec("show_tab"),
-    show_pager = rec("show_pager"),
-    show_demo = rec("show_demo"),
-    toggle = rec("toggle"),
-    split = rec("split"),
-    auto_on = rec("auto_on"),
-    auto_off = rec("auto_off"),
-    auto_toggle = rec("auto_toggle"),
+    show = rec "show",
+    show_tab = rec "show_tab",
+    show_pager = rec "show_pager",
+    show_demo = rec "show_demo",
+    toggle = rec "toggle",
+    split = rec "split",
+    auto_on = rec "auto_on",
+    auto_off = rec "auto_off",
+    auto_toggle = rec "auto_toggle",
   }
   local prev = package.loaded["md-render"]
   package.loaded["md-render"] = { preview = stub_preview }
@@ -80,9 +80,7 @@ local function with_notify_stub()
   -- across tests).
   local seen = {}
   vim.notify_once = function(msg, level)
-    if seen[msg] then
-      return false
-    end
+    if seen[msg] then return false end
     seen[msg] = true
     table.insert(calls, { kind = "notify_once", msg = msg, level = level })
     return true
@@ -99,7 +97,7 @@ end
 -- ----------------------------------------------------------------------
 test("dispatch with no args calls preview.show (float default)", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = {} })
+  cmd.dispatch { fargs = {} }
   assert_eq(#calls, 1, "exactly one preview call")
   assert_eq(calls[1].fn, "show", "should route to show")
   restore()
@@ -107,35 +105,35 @@ end)
 
 test("dispatch float -> preview.show", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "float" } })
+  cmd.dispatch { fargs = { "float" } }
   assert_eq(calls[1].fn, "show", "float -> show")
   restore()
 end)
 
 test("dispatch tab -> preview.show_tab", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "tab" } })
+  cmd.dispatch { fargs = { "tab" } }
   assert_eq(calls[1].fn, "show_tab", "tab -> show_tab")
   restore()
 end)
 
 test("dispatch pager -> preview.show_pager", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "pager" } })
+  cmd.dispatch { fargs = { "pager" } }
   assert_eq(calls[1].fn, "show_pager", "pager -> show_pager")
   restore()
 end)
 
 test("dispatch toggle -> preview.toggle", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "toggle" } })
+  cmd.dispatch { fargs = { "toggle" } }
   assert_eq(calls[1].fn, "toggle", "toggle -> toggle")
   restore()
 end)
 
 test("dispatch demo -> preview.show_demo", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "demo" } })
+  cmd.dispatch { fargs = { "demo" } }
   assert_eq(calls[1].fn, "show_demo", "demo -> show_demo")
   restore()
 end)
@@ -143,7 +141,7 @@ end)
 test("dispatch split forwards smods to preview.split", function()
   local cmd, calls, restore = with_preview_stub()
   local fake_smods = { vertical = true, tab = -1 }
-  cmd.dispatch({ fargs = { "split" }, smods = fake_smods })
+  cmd.dispatch { fargs = { "split" }, smods = fake_smods }
   assert_eq(calls[1].fn, "split", "split -> split")
   assert_eq(calls[1].args[1], { mods = fake_smods }, "split args carry smods as mods")
   restore()
@@ -151,28 +149,28 @@ end)
 
 test("dispatch auto (no second arg) -> auto_toggle", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "auto" } })
+  cmd.dispatch { fargs = { "auto" } }
   assert_eq(calls[1].fn, "auto_toggle", "bare auto -> auto_toggle")
   restore()
 end)
 
 test("dispatch auto on -> auto_on", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "auto", "on" } })
+  cmd.dispatch { fargs = { "auto", "on" } }
   assert_eq(calls[1].fn, "auto_on", "auto on -> auto_on")
   restore()
 end)
 
 test("dispatch auto off -> auto_off", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "auto", "off" } })
+  cmd.dispatch { fargs = { "auto", "off" } }
   assert_eq(calls[1].fn, "auto_off", "auto off -> auto_off")
   restore()
 end)
 
 test("dispatch auto toggle -> auto_toggle", function()
   local cmd, calls, restore = with_preview_stub()
-  cmd.dispatch({ fargs = { "auto", "toggle" } })
+  cmd.dispatch { fargs = { "auto", "toggle" } }
   assert_eq(calls[1].fn, "auto_toggle", "auto toggle -> auto_toggle")
   restore()
 end)
@@ -180,11 +178,11 @@ end)
 test("dispatch auto bogus -> warn, no preview call", function()
   local cmd, calls, restore = with_preview_stub()
   local notif, restore_n = with_notify_stub()
-  cmd.dispatch({ fargs = { "auto", "bogus" } })
+  cmd.dispatch { fargs = { "auto", "bogus" } }
   assert_eq(#calls, 0, "no preview call on bogus auto arg")
   assert_eq(#notif, 1, "one warning emitted")
   assert_eq(notif[1].level, vim.log.levels.WARN, "warn level")
-  assert_true(notif[1].msg:match("auto"), "warning mentions auto")
+  assert_true(notif[1].msg:match "auto", "warning mentions auto")
   restore_n()
   restore()
 end)
@@ -192,11 +190,11 @@ end)
 test("dispatch unknown subcommand -> warn, no preview call", function()
   local cmd, calls, restore = with_preview_stub()
   local notif, restore_n = with_notify_stub()
-  cmd.dispatch({ fargs = { "wibble" } })
+  cmd.dispatch { fargs = { "wibble" } }
   assert_eq(#calls, 0, "no preview call on unknown subcommand")
   assert_eq(#notif, 1, "one warning emitted")
   assert_eq(notif[1].level, vim.log.levels.WARN, "warn level")
-  assert_true(notif[1].msg:match("wibble"), "warning includes the bad subcommand")
+  assert_true(notif[1].msg:match "wibble", "warning includes the bad subcommand")
   restore_n()
   restore()
 end)
@@ -208,8 +206,11 @@ test("complete first arg empty -> all subcommands", function()
   local cmd, _, restore = with_preview_stub()
   local out = cmd.complete("", "MdRender ", #"MdRender ")
   -- Order matches the SUBCOMMANDS table
-  assert_eq(out, { "float", "tab", "pager", "toggle", "split", "auto", "demo" },
-    "all subcommands returned for empty arglead")
+  assert_eq(
+    out,
+    { "float", "tab", "pager", "toggle", "split", "auto", "demo" },
+    "all subcommands returned for empty arglead"
+  )
   restore()
 end)
 
@@ -237,8 +238,11 @@ end)
 test("complete tolerates :vert mod prefix", function()
   local cmd, _, restore = with_preview_stub()
   local out = cmd.complete("", "vert MdRender ", #"vert MdRender ")
-  assert_eq(out, { "float", "tab", "pager", "toggle", "split", "auto", "demo" },
-    "leading :vert mod still yields full subcommand list")
+  assert_eq(
+    out,
+    { "float", "tab", "pager", "toggle", "split", "auto", "demo" },
+    "leading :vert mod still yields full subcommand list"
+  )
   restore()
 end)
 
@@ -259,22 +263,20 @@ test("deprecated wrapper warns once and forwards args", function()
   local handler = cmd.deprecated("MdRenderToggle", "MdRender toggle", function(args)
     table.insert(seen_args, args)
   end)
-  handler({ fargs = { "x" } })
-  handler({ fargs = { "y" } })
-  handler({ fargs = { "z" } })
+  handler { fargs = { "x" } }
+  handler { fargs = { "y" } }
+  handler { fargs = { "z" } }
   assert_eq(#seen_args, 3, "handler runs every time")
   assert_eq(seen_args[1].fargs, { "x" }, "first call args forwarded")
   assert_eq(seen_args[3].fargs, { "z" }, "third call args forwarded")
   assert_eq(#notif, 1, "warning fires only once across calls")
   assert_eq(notif[1].kind, "notify_once", "uses notify_once")
   assert_eq(notif[1].level, vim.log.levels.WARN, "warn level")
-  assert_true(notif[1].msg:match("MdRenderToggle"), "warning names the deprecated command")
-  assert_true(notif[1].msg:match("MdRender toggle"), "warning suggests the new form")
+  assert_true(notif[1].msg:match "MdRenderToggle", "warning names the deprecated command")
+  assert_true(notif[1].msg:match "MdRender toggle", "warning suggests the new form")
   restore_n()
   restore()
 end)
 
 print(string.format("command_test: %d passed, %d failed", pass_count, fail_count))
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/display_utils_test.lua
+++ b/tests/display_utils_test.lua
@@ -65,11 +65,7 @@ end)
 test("resolve_lang honors vim.treesitter.language.register", function()
   -- Simulate a user-registered alias and confirm it wins over the literal name.
   vim.treesitter.language.register("markdown", "custom_md_lang")
-  assert_eq(
-    display_utils._resolve_lang "custom_md_lang",
-    "markdown",
-    "registered alias custom_md_lang -> markdown"
-  )
+  assert_eq(display_utils._resolve_lang "custom_md_lang", "markdown", "registered alias custom_md_lang -> markdown")
 end)
 
 print(string.format("display_utils_test: %d passed, %d failed", pass_count, fail_count))

--- a/tests/figure_test.lua
+++ b/tests/figure_test.lua
@@ -36,12 +36,12 @@ end
 
 -- Test 1: <em> inside <figcaption> is stripped (not shown literally)
 do
-  local out = render({
-    "<figure align=\"center\">",
-    "  <img src=\"x.png\" alt=\"x\" />",
+  local out = render {
+    '<figure align="center">',
+    '  <img src="x.png" alt="x" />',
     "  <figcaption><em>caption text</em></figcaption>",
     "</figure>",
-  })
+  }
   assert_false(any_line_contains(out, "<em>"), "<em> opening tag should not appear in output")
   assert_false(any_line_contains(out, "</em>"), "</em> closing tag should not appear in output")
   assert_true(any_line_contains(out, "caption text"), "caption text should appear in output")
@@ -52,7 +52,7 @@ do
   local long_caption = string.rep("word ", 30):gsub("%s+$", "")
   local out = render({
     "<figure>",
-    "  <img src=\"x.png\" alt=\"x\" />",
+    '  <img src="x.png" alt="x" />',
     "  <figcaption>" .. long_caption .. "</figcaption>",
     "</figure>",
   }, { max_width = 40, indent = "  " })
@@ -67,12 +67,12 @@ end
 
 -- Test 3: caption highlights include "Comment" base
 do
-  local out = render({
+  local out = render {
     "<figure>",
-    "  <img src=\"x.png\" alt=\"x\" />",
+    '  <img src="x.png" alt="x" />',
     "  <figcaption>plain caption</figcaption>",
     "</figure>",
-  })
+  }
   local found_comment = false
   for _, entry in ipairs(out.highlights or {}) do
     for _, hl in ipairs(entry.groups or {}) do

--- a/tests/html_table_test.lua
+++ b/tests/html_table_test.lua
@@ -204,6 +204,4 @@ do
 end
 
 print(pass_count .. " passed, " .. fail_count .. " failed")
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/image_test.lua
+++ b/tests/image_test.lua
@@ -102,7 +102,7 @@ local function parse_kitty_sequences(data)
   while pos <= #data do
     local s, e, content = data:find("\x1b_G(.-)\x1b\\", pos)
     if not s then break end
-    local params, payload = content:match("^([^;]*);(.*)$")
+    local params, payload = content:match "^([^;]*);(.*)$"
     if not params then
       params = content
       payload = ""
@@ -116,7 +116,7 @@ end
 --- Parse params string "a=t,f=100,..." into a table { a="t", f="100", ... }
 local function parse_params(params_str)
   local t = {}
-  for k, v in params_str:gmatch("([%w_]+)=([^,]*)") do
+  for k, v in params_str:gmatch "([%w_]+)=([^,]*)" do
     t[k] = v
   end
   return t
@@ -268,7 +268,9 @@ test("put_image: generates correct placement sequence", function()
   local buf = vim.api.nvim_create_buf(false, true)
   -- Fill buffer with enough lines for the image
   local lines = {}
-  for i = 1, 20 do lines[i] = string.rep(" ", 40) end
+  for i = 1, 20 do
+    lines[i] = string.rep(" ", 40)
+  end
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   local win = vim.api.nvim_open_win(buf, false, {
     relative = "editor",
@@ -310,7 +312,9 @@ test("put_image: skips image outside visible area (below)", function()
 
   local buf = vim.api.nvim_create_buf(false, true)
   local lines = {}
-  for i = 1, 5 do lines[i] = string.rep(" ", 40) end
+  for i = 1, 5 do
+    lines[i] = string.rep(" ", 40)
+  end
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   local win = vim.api.nvim_open_win(buf, false, {
     relative = "editor",
@@ -351,7 +355,9 @@ test("put_image: bottom crop emits full source rectangle", function()
 
   local buf = vim.api.nvim_create_buf(false, true)
   local lines = {}
-  for i = 1, 30 do lines[i] = string.rep(" ", 80) end
+  for i = 1, 30 do
+    lines[i] = string.rep(" ", 80)
+  end
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   local win = vim.api.nvim_open_win(buf, false, {
     relative = "editor",
@@ -391,7 +397,9 @@ test("put_image: top crop generates y= and h= parameters", function()
 
   local buf = vim.api.nvim_create_buf(false, true)
   local lines = {}
-  for i = 1, 10 do lines[i] = string.rep(" ", 40) end
+  for i = 1, 10 do
+    lines[i] = string.rep(" ", 40)
+  end
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   local win = vim.api.nvim_open_win(buf, false, {
     relative = "editor",
@@ -471,7 +479,7 @@ end)
 
 test("delete_images: generates multiple delete sequences", function()
   setup_capture()
-  image.delete_images({ 10, 20, 30 })
+  image.delete_images { 10, 20, 30 }
 
   local output = captured_output()
   local seqs = parse_kitty_sequences(output)
@@ -496,7 +504,7 @@ end)
 
 test("delete_images: does nothing for empty list", function()
   setup_capture()
-  image.delete_images({})
+  image.delete_images {}
   assert_eq(#captured, 0, "should not write anything for empty list")
   teardown()
 end)
@@ -525,7 +533,7 @@ test("image_dimensions: reads PNG dimensions correctly", function()
 end)
 
 test("image_dimensions: returns nil for non-existent file", function()
-  local w, h = image.image_dimensions("/nonexistent/path.png")
+  local w, h = image.image_dimensions "/nonexistent/path.png"
   assert_nil(w, "width should be nil for missing file")
   assert_nil(h, "height should be nil for missing file")
 end)
@@ -604,11 +612,11 @@ end)
 -- ============================================================================
 
 test("is_badge_url: detects shields.io", function()
-  assert_true(image.is_badge_url("https://img.shields.io/badge/foo-bar"), "shields.io should be badge")
+  assert_true(image.is_badge_url "https://img.shields.io/badge/foo-bar", "shields.io should be badge")
 end)
 
 test("is_badge_url: normal URL is not badge", function()
-  assert_true(not image.is_badge_url("https://example.com/photo.png"), "normal URL should not be badge")
+  assert_true(not image.is_badge_url "https://example.com/photo.png", "normal URL should not be badge")
 end)
 
 -- ============================================================================
@@ -616,15 +624,15 @@ end)
 -- ============================================================================
 
 test("is_url: detects http URL", function()
-  assert_true(image.is_url("http://example.com/img.png"), "http should be URL")
+  assert_true(image.is_url "http://example.com/img.png", "http should be URL")
 end)
 
 test("is_url: detects https URL", function()
-  assert_true(image.is_url("https://example.com/img.png"), "https should be URL")
+  assert_true(image.is_url "https://example.com/img.png", "https should be URL")
 end)
 
 test("is_url: rejects file path", function()
-  assert_true(not image.is_url("/path/to/file.png"), "file path should not be URL")
+  assert_true(not image.is_url "/path/to/file.png", "file path should not be URL")
 end)
 
 -- ============================================================================
@@ -684,12 +692,14 @@ test("get_cell_size: returns nil or table without crashing (no override)", funct
   -- In headless nvim stdout is not a TTY and there's no controlling terminal,
   -- so result is normally nil. In a real terminal it returns a {cell_w,cell_h}
   -- table. Both are valid; the contract is "must not crash".
-  assert_true(result == nil or (type(result) == "table" and result.cell_w and result.cell_h),
-    "get_cell_size should return nil or {cell_w, cell_h}")
+  assert_true(
+    result == nil or (type(result) == "table" and result.cell_w and result.cell_h),
+    "get_cell_size should return nil or {cell_w, cell_h}"
+  )
 end)
 
 test("supports_kitty: returns boolean without crashing", function()
-  image._set_kitty_supported(nil)  -- clear cache so detection runs
+  image._set_kitty_supported(nil) -- clear cache so detection runs
   local result = image.supports_kitty()
   assert_true(result == true or result == false, "supports_kitty should return a boolean")
   image._set_kitty_supported(nil)
@@ -709,15 +719,14 @@ if ffi.os == "Linux" then
   pcall(ffi.cdef, "int open(const char *path, int flags); int close(int fd);")
 
   test("Linux: winsize struct size is 8 bytes", function()
-    assert_eq(ffi.sizeof("winsize"), 8,
-      "winsize should be 8 bytes (4 unsigned shorts)")
+    assert_eq(ffi.sizeof "winsize", 8, "winsize should be 8 bytes (4 unsigned shorts)")
   end)
 
   test("Linux: ioctl(TIOCGWINSZ) on non-TTY fd fails cleanly", function()
     local TIOCGWINSZ_LINUX = 0x5413
     local fd = ffi.C.open("/dev/null", 0) -- O_RDONLY
     assert_true(fd >= 0, "open /dev/null should succeed")
-    local sz = ffi.new("winsize")
+    local sz = ffi.new "winsize"
     local rc = ffi.C.ioctl(fd, TIOCGWINSZ_LINUX, sz)
     -- /dev/null is not a TTY, so ioctl must fail (rc != 0). The contract is
     -- "must not segfault"; a clean failure is the success case.
@@ -731,20 +740,18 @@ end
 -- ============================================================================
 
 local function has_convert_tool()
-  return vim.fn.executable("sips") == 1
-    or vim.fn.executable("ffmpeg") == 1
-    or vim.fn.executable("magick") == 1
+  return vim.fn.executable "sips" == 1 or vim.fn.executable "ffmpeg" == 1 or vim.fn.executable "magick" == 1
 end
 
 --- Convert the PNG fixture to a temporary JPEG so we have a non-native source.
 --- Returns nil if no conversion tool is available.
 local function make_test_jpeg()
   local out = vim.fn.tempname() .. ".jpg"
-  if vim.fn.executable("sips") == 1 then
+  if vim.fn.executable "sips" == 1 then
     vim.system({ "sips", "-s", "format", "jpeg", test_png, "--out", out }, { text = true }):wait()
-  elseif vim.fn.executable("ffmpeg") == 1 then
+  elseif vim.fn.executable "ffmpeg" == 1 then
     vim.system({ "ffmpeg", "-y", "-i", test_png, out }, { text = true }):wait()
-  elseif vim.fn.executable("magick") == 1 then
+  elseif vim.fn.executable "magick" == 1 then
     vim.system({ "magick", test_png, out }, { text = true }):wait()
   else
     return nil
@@ -757,7 +764,7 @@ if has_convert_tool() then
   test("ensure_png: caches converted JPEG to disk", function()
     local jpeg = make_test_jpeg()
     if not jpeg then return end
-    local cache_dir = vim.fn.stdpath("cache") .. "/md-render/converted"
+    local cache_dir = vim.fn.stdpath "cache" .. "/md-render/converted"
     -- Clean cache for this hash so the count is meaningful
     vim.fn.mkdir(cache_dir, "p")
     local hash = vim.fn.sha256(jpeg):sub(1, 16)
@@ -808,7 +815,7 @@ if has_convert_tool() then
   test("ensure_png: mtime change invalidates cache", function()
     local jpeg = make_test_jpeg()
     if not jpeg then return end
-    local cache_dir = vim.fn.stdpath("cache") .. "/md-render/converted"
+    local cache_dir = vim.fn.stdpath "cache" .. "/md-render/converted"
     vim.fn.mkdir(cache_dir, "p")
     local hash = vim.fn.sha256(jpeg):sub(1, 16)
     for _, p in ipairs(vim.fn.glob(cache_dir .. "/" .. hash .. "_*", false, true)) do
@@ -837,6 +844,4 @@ end
 -- ============================================================================
 
 print(string.format("\n%d passed, %d failed", pass_count, fail_count))
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/key_toggle_test.lua
+++ b/tests/key_toggle_test.lua
@@ -205,6 +205,4 @@ test("<CR> still closes when explicitly a close key", function()
 end)
 
 print(string.format("key_toggle_test: %d passed, %d failed", pass_count, fail_count))
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/link_types_test.lua
+++ b/tests/link_types_test.lua
@@ -41,60 +41,64 @@ end
 -- heading_slug tests
 
 test("heading_slug: simple text", function()
-  assert_eq(Markdown.heading_slug("Hello World"), "hello-world", "simple heading slug")
+  assert_eq(Markdown.heading_slug "Hello World", "hello-world", "simple heading slug")
 end)
 
 test("heading_slug: strips bold markers", function()
-  assert_eq(Markdown.heading_slug("My **Bold** Heading"), "my-bold-heading", "bold markers stripped")
+  assert_eq(Markdown.heading_slug "My **Bold** Heading", "my-bold-heading", "bold markers stripped")
 end)
 
 test("heading_slug: strips inline code", function()
-  assert_eq(Markdown.heading_slug("Using `code` here"), "using-code-here", "code markers stripped")
+  assert_eq(Markdown.heading_slug "Using `code` here", "using-code-here", "code markers stripped")
 end)
 
 test("heading_slug: strips link syntax", function()
-  assert_eq(Markdown.heading_slug("See [docs](https://example.com)"), "see-docs", "link syntax stripped")
+  assert_eq(Markdown.heading_slug "See [docs](https://example.com)", "see-docs", "link syntax stripped")
 end)
 
 test("heading_slug: strips wikilink syntax", function()
-  assert_eq(Markdown.heading_slug("About [[Page|display]]"), "about-display", "wikilink syntax stripped")
+  assert_eq(Markdown.heading_slug "About [[Page|display]]", "about-display", "wikilink syntax stripped")
 end)
 
 test("heading_slug: collapses hyphens", function()
-  assert_eq(Markdown.heading_slug("A - B - C"), "a-b-c", "hyphens collapsed")
+  assert_eq(Markdown.heading_slug "A - B - C", "a-b-c", "hyphens collapsed")
 end)
 
 test("heading_slug: removes special characters", function()
-  assert_eq(Markdown.heading_slug("What's New?"), "whats-new", "special chars removed")
+  assert_eq(Markdown.heading_slug "What's New?", "whats-new", "special chars removed")
 end)
 
 test("heading_slug: Japanese text preserved", function()
-  local slug = Markdown.heading_slug("日本語テスト")
+  local slug = Markdown.heading_slug "日本語テスト"
   assert_eq(slug, "日本語テスト", "Japanese text preserved in slug")
 end)
 
 -- Wikilink URL generation tests
 
 test("wikilink [[#heading]] generates anchor URL", function()
-  local _, _, links = Markdown.render("[[#My Heading]]")
+  local _, _, links = Markdown.render "[[#My Heading]]"
   assert_eq(#links, 1, "wikilink anchor: one link")
   assert_eq(links[1].url, "#my-heading", "wikilink anchor: URL is #slug")
 end)
 
 test("wikilink [[page]] generates advanced-uri URL", function()
-  local _, _, links = Markdown.render("[[SomePage]]")
+  local _, _, links = Markdown.render "[[SomePage]]"
   assert_eq(#links, 1, "wikilink page: one link")
   assert_eq(links[1].url, "obsidian://advanced-uri?filepath=SomePage", "wikilink page: advanced-uri URL")
 end)
 
 test("wikilink [[page#heading]] generates advanced-uri URL with heading", function()
-  local _, _, links = Markdown.render("[[SomePage#Section]]")
+  local _, _, links = Markdown.render "[[SomePage#Section]]"
   assert_eq(#links, 1, "wikilink page#heading: one link")
-  assert_eq(links[1].url, "obsidian://advanced-uri?filepath=SomePage&heading=Section", "wikilink page#heading: advanced-uri with heading")
+  assert_eq(
+    links[1].url,
+    "obsidian://advanced-uri?filepath=SomePage&heading=Section",
+    "wikilink page#heading: advanced-uri with heading"
+  )
 end)
 
 test("wikilink [[#heading|alias]] generates anchor URL", function()
-  local _, _, links = Markdown.render("[[#My Section|go here]]")
+  local _, _, links = Markdown.render "[[#My Section|go here]]"
   assert_eq(#links, 1, "wikilink anchor alias: one link")
   assert_eq(links[1].url, "#my-section", "wikilink anchor alias: URL is #slug")
 end)
@@ -102,13 +106,13 @@ end)
 -- Standard link anchor detection
 
 test("standard link [text](#anchor) has anchor URL", function()
-  local _, _, links = Markdown.render("[click here](#some-heading)")
+  local _, _, links = Markdown.render "[click here](#some-heading)"
   assert_eq(#links, 1, "standard anchor: one link")
   assert_eq(links[1].url, "#some-heading", "standard anchor: URL preserved")
 end)
 
 test("standard link [text](https://...) has external URL", function()
-  local _, _, links = Markdown.render("[click](https://example.com)")
+  local _, _, links = Markdown.render "[click](https://example.com)"
   assert_eq(#links, 1, "external link: one link")
   assert_match(links[1].url, "^https://", "external link: URL is https")
 end)
@@ -117,7 +121,7 @@ end)
 -- Angle brackets are delimiters and must not appear in rendered output.
 
 test("autolink <URL> strips angle brackets and registers link", function()
-  local rendered, _, links = Markdown.render("<https://example.com>")
+  local rendered, _, links = Markdown.render "<https://example.com>"
   assert_eq(rendered, "https://example.com", "autolink: brackets stripped")
   assert_eq(#links, 1, "autolink: one link")
   assert_eq(links[1].url, "https://example.com", "autolink: URL preserved")
@@ -126,7 +130,7 @@ test("autolink <URL> strips angle brackets and registers link", function()
 end)
 
 test("autolink coexists with surrounding text", function()
-  local rendered, _, links = Markdown.render("See <https://example.com> for more")
+  local rendered, _, links = Markdown.render "See <https://example.com> for more"
   assert_eq(rendered, "See https://example.com for more", "inline autolink: brackets stripped")
   assert_eq(#links, 1, "inline autolink: one link")
   assert_eq(links[1].col_start, 4, "inline autolink: starts after 'See '")
@@ -151,7 +155,9 @@ end)
 local function with_kitty_stubbed(fn)
   local image = require "md-render.image"
   local original = image.supports_kitty
-  image.supports_kitty = function() return true end
+  image.supports_kitty = function()
+    return true
+  end
   local ok, err = pcall(fn)
   image.supports_kitty = original
   if not ok then error(err) end
@@ -166,7 +172,10 @@ test("standalone autolink to user-attachments registers image placement", functi
     local result = b:result()
     local found
     for _, p in ipairs(result.image_placements or {}) do
-      if p.src_url == url then found = p; break end
+      if p.src_url == url then
+        found = p
+        break
+      end
     end
     assert_eq(found ~= nil, true, "user-attachments autolink: image placement registered")
     assert_eq(found and found.src_url, url, "user-attachments autolink: src_url preserved")
@@ -182,7 +191,7 @@ test("standalone autolink to non-attachments URL does NOT become a placement", f
     for _, p in ipairs(result.image_placements or {}) do
       if p.src_url == "https://example.com/page" then
         fail_count = fail_count + 1
-        print("FAIL: non-attachments autolink should not become an image placement")
+        print "FAIL: non-attachments autolink should not become an image placement"
         return
       end
     end
@@ -193,7 +202,7 @@ end)
 -- Highlight tests for wikilinks
 
 test("wikilink [[#heading]] uses MdRenderLinkAnchor highlight", function()
-  local _, highlights = Markdown.render("[[#Heading]]")
+  local _, highlights = Markdown.render "[[#Heading]]"
   local found = false
   for _, hl in ipairs(highlights) do
     if hl.hl == "MdRenderLinkAnchor" then found = true end
@@ -202,7 +211,7 @@ test("wikilink [[#heading]] uses MdRenderLinkAnchor highlight", function()
 end)
 
 test("wikilink [[page]] uses MdRenderLinkObsidian highlight", function()
-  local _, highlights = Markdown.render("[[SomePage]]")
+  local _, highlights = Markdown.render "[[SomePage]]"
   local found = false
   for _, hl in ipairs(highlights) do
     if hl.hl == "MdRenderLinkObsidian" then found = true end
@@ -226,7 +235,7 @@ test("content_builder heading anchor line is correct", function()
   local ContentBuilder = require("md-render.content_builder").ContentBuilder
   local b = ContentBuilder.new()
   b:set_source_line(1)
-  b:add_line("first line")
+  b:add_line "first line"
   b:set_source_line(2)
   b:add_markdown_line("## Second Heading", "", 80)
   local result = b:result()
@@ -235,6 +244,4 @@ end)
 
 -- Summary
 print(string.format("\n%d passed, %d failed", pass_count, fail_count))
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/markdown_checkbox_test.lua
+++ b/tests/markdown_checkbox_test.lua
@@ -35,7 +35,7 @@ end
 
 -- Unchecked checkbox
 test("unchecked checkbox text", function()
-  local text, highlights, list_marker = render("- [ ] todo item")
+  local text, highlights, list_marker = render "- [ ] todo item"
   -- list_marker should be the icon (no dash)
   assert_eq(list_marker:match "^%s*[-*]", nil, "unchecked: list_marker should not contain dash")
   -- rendered text should not contain [ ]
@@ -50,7 +50,7 @@ end)
 
 -- Checked checkbox (lowercase x)
 test("checked checkbox text", function()
-  local text, highlights, list_marker = render("- [x] done item")
+  local text, highlights, list_marker = render "- [x] done item"
   assert_eq(text:find "%[x%]", nil, "checked: rendered text should not contain [x]")
   assert_eq(text:match "^%- ", nil, "checked: rendered text should not start with '- '")
   assert(text:find "done item", "checked: rendered text should contain 'done item'")
@@ -59,14 +59,14 @@ end)
 
 -- Checked checkbox (uppercase X)
 test("checked checkbox uppercase X", function()
-  local text, highlights, list_marker = render("- [X] done item")
+  local text, highlights, list_marker = render "- [X] done item"
   assert_eq(text:find "%[X%]", nil, "checked uppercase: rendered text should not contain [X]")
   assert_eq(highlights[1].hl, "DiagnosticOk", "checked uppercase: highlight should be DiagnosticOk")
 end)
 
 -- Partial checkbox (-)
 test("partial checkbox text", function()
-  local text, highlights, list_marker = render("- [-] in progress")
+  local text, highlights, list_marker = render "- [-] in progress"
   assert_eq(text:find "%[%-%]", nil, "partial: rendered text should not contain [-]")
   assert(text:find "in progress", "partial: rendered text should contain 'in progress'")
   assert_eq(highlights[1].hl, "DiagnosticWarn", "partial: highlight should be DiagnosticWarn")
@@ -74,7 +74,7 @@ end)
 
 -- Normal list item (no checkbox) - bullet replaced with •
 test("normal list item bullet symbol", function()
-  local text, highlights, list_marker = render("- normal item")
+  local text, highlights, list_marker = render "- normal item"
   assert_eq(list_marker:find "[-*+]", nil, "normal: list_marker should not contain raw bullet")
   assert(list_marker:find "•", "normal: list_marker should contain •")
   assert(text:find "normal item", "normal: rendered text should contain 'normal item'")
@@ -83,21 +83,21 @@ end)
 
 -- Asterisk list marker with checkbox
 test("asterisk list marker checkbox", function()
-  local text, highlights, list_marker = render("* [x] done")
+  local text, highlights, list_marker = render "* [x] done"
   assert_eq(text:find "%[x%]", nil, "asterisk: rendered text should not contain [x]")
   assert_eq(highlights[1].hl, "DiagnosticOk", "asterisk: highlight should be DiagnosticOk")
 end)
 
 -- Ordered list with checkbox
 test("ordered list checkbox", function()
-  local text, highlights, list_marker = render("1. [x] done")
+  local text, highlights, list_marker = render "1. [x] done"
   assert_eq(text:find "%[x%]", nil, "ordered: rendered text should not contain [x]")
   assert_eq(highlights[1].hl, "DiagnosticOk", "ordered: highlight should be DiagnosticOk")
 end)
 
 -- Indented checkbox
 test("indented checkbox", function()
-  local text, highlights, list_marker = render("  - [x] nested done")
+  local text, highlights, list_marker = render "  - [x] nested done"
   assert_eq(text:find "%[x%]", nil, "indented: rendered text should not contain [x]")
   assert(text:find "nested done", "indented: rendered text should contain 'nested done'")
   -- list_marker should preserve leading whitespace
@@ -109,7 +109,7 @@ end)
 
 -- Highlight range should cover only the icon, not content text
 test("highlight covers only icon", function()
-  local text, highlights, list_marker = render("- [x] some content")
+  local text, highlights, list_marker = render "- [x] some content"
   local hl = highlights[1]
   -- The highlight should end at the list_marker boundary (icon + space)
   assert_eq(hl.end_col, #list_marker, "icon hl: end_col should equal list_marker byte length")
@@ -119,13 +119,13 @@ end)
 
 -- Text without checkbox should not be affected
 test("non-list text unaffected", function()
-  local text, highlights, list_marker = render("just some text")
+  local text, highlights, list_marker = render "just some text"
   assert_eq(list_marker, nil, "non-list: list_marker should be nil")
 end)
 
 -- Checkbox with inline formatting
 test("checkbox with bold content", function()
-  local text, highlights, list_marker = render("- [x] **bold task**")
+  local text, highlights, list_marker = render "- [x] **bold task**"
   assert_eq(text:find "%[x%]", nil, "bold: rendered text should not contain [x]")
   assert(text:find "bold task", "bold: rendered text should contain 'bold task'")
   -- Should have checkbox highlight and bold highlight
@@ -142,49 +142,49 @@ end)
 -- Bullet symbol replacement tests
 
 test("bullet: dash replaced with •", function()
-  local text, highlights, list_marker = render("- item")
+  local text, highlights, list_marker = render "- item"
   assert(list_marker:find "•", "dash: should use • symbol")
   assert_eq(list_marker:find "-", nil, "dash: should not contain raw -")
 end)
 
 test("bullet: asterisk replaced with •", function()
-  local text, highlights, list_marker = render("* item")
+  local text, highlights, list_marker = render "* item"
   assert(list_marker:find "•", "asterisk: should use • symbol")
 end)
 
 test("bullet: plus replaced with •", function()
-  local text, highlights, list_marker = render("+ item")
+  local text, highlights, list_marker = render "+ item"
   assert(list_marker:find "•", "plus: should use • symbol")
 end)
 
 test("bullet: nested level 1 uses ◦", function()
-  local text, highlights, list_marker = render("  - nested item")
+  local text, highlights, list_marker = render "  - nested item"
   assert(list_marker:find "◦", "nested 1: should use ◦ symbol")
 end)
 
 test("bullet: nested level 2 uses ▪", function()
-  local text, highlights, list_marker = render("    - deep item")
+  local text, highlights, list_marker = render "    - deep item"
   assert(list_marker:find "▪", "nested 2: should use ▪ symbol")
 end)
 
 test("bullet: nested level 3 cycles back to •", function()
-  local text, highlights, list_marker = render("      - very deep item")
+  local text, highlights, list_marker = render "      - very deep item"
   assert(list_marker:find "•", "nested 3: should cycle back to • symbol")
 end)
 
 test("bullet: preserves indent in list_marker", function()
-  local text, highlights, list_marker = render("  - nested")
+  local text, highlights, list_marker = render "  - nested"
   assert_eq(list_marker:match "^(%s+)", "  ", "nested: should preserve 2-space indent")
 end)
 
 test("ordered list: 1) style detected", function()
-  local text, highlights, list_marker = render("1) item")
+  local text, highlights, list_marker = render "1) item"
   assert_eq(list_marker, "1) ", "1) style: list_marker should be '1) '")
 end)
 
 test("bullet in blockquote: symbol replaced", function()
   local Markdown = require "md-render.markdown"
-  local text, highlights, links, special_type, list_marker = Markdown.render("> - item in quote")
+  local text, highlights, links, special_type, list_marker = Markdown.render "> - item in quote"
   assert_eq(special_type, "blockquote", "bq bullet: should be blockquote")
   assert(list_marker and list_marker:find "•", "bq bullet: list_marker should contain •")
   assert(text:find "item in quote", "bq bullet: should contain content")
@@ -192,42 +192,42 @@ end)
 
 test("ordered list in blockquote: marker preserved", function()
   local Markdown = require "md-render.markdown"
-  local text, highlights, links, special_type, list_marker = Markdown.render("> 1. first item")
+  local text, highlights, links, special_type, list_marker = Markdown.render "> 1. first item"
   assert_eq(special_type, "blockquote", "bq ordered: should be blockquote")
   assert_eq(list_marker, "1. ", "bq ordered: list_marker should be '1. '")
 end)
 
 -- list_marker_type tests (CommonMark: same character/delimiter = same list)
 test("list_marker_type: dash", function()
-  assert_eq(Markdown.list_marker_type("- item"), "-", "dash should return '-'")
+  assert_eq(Markdown.list_marker_type "- item", "-", "dash should return '-'")
 end)
 
 test("list_marker_type: asterisk", function()
-  assert_eq(Markdown.list_marker_type("* item"), "*", "asterisk should return '*'")
+  assert_eq(Markdown.list_marker_type "* item", "*", "asterisk should return '*'")
 end)
 
 test("list_marker_type: plus", function()
-  assert_eq(Markdown.list_marker_type("+ item"), "+", "plus should return '+'")
+  assert_eq(Markdown.list_marker_type "+ item", "+", "plus should return '+'")
 end)
 
 test("list_marker_type: ordered dot", function()
-  assert_eq(Markdown.list_marker_type("1. item"), ".", "ordered dot should return '.'")
+  assert_eq(Markdown.list_marker_type "1. item", ".", "ordered dot should return '.'")
 end)
 
 test("list_marker_type: ordered paren", function()
-  assert_eq(Markdown.list_marker_type("1) item"), ")", "ordered paren should return ')'")
+  assert_eq(Markdown.list_marker_type "1) item", ")", "ordered paren should return ')'")
 end)
 
 test("list_marker_type: indented dash", function()
-  assert_eq(Markdown.list_marker_type("  - item"), "-", "indented dash should return '-'")
+  assert_eq(Markdown.list_marker_type "  - item", "-", "indented dash should return '-'")
 end)
 
 test("list_marker_type: non-list", function()
-  assert_eq(Markdown.list_marker_type("just text"), nil, "plain text should be nil")
+  assert_eq(Markdown.list_marker_type "just text", nil, "plain text should be nil")
 end)
 
 test("list_marker_type: blank line", function()
-  assert_eq(Markdown.list_marker_type(""), nil, "blank line should be nil")
+  assert_eq(Markdown.list_marker_type "", nil, "blank line should be nil")
 end)
 
 -- render_document loose list collapsing tests
@@ -240,13 +240,13 @@ local function render_doc(input_lines, opts)
 end
 
 test("loose list: blank lines between same-type items are collapsed", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "- item 1",
     "",
     "- item 2",
     "",
     "- item 3",
-  })
+  }
   -- Should have 3 lines, no blank lines
   local blank_count = 0
   for _, l in ipairs(lines) do
@@ -257,11 +257,11 @@ test("loose list: blank lines between same-type items are collapsed", function()
 end)
 
 test("loose list: blank lines between different marker types are kept (ul vs ol)", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "- item 1",
     "",
     "1. item 2",
-  })
+  }
   local blank_count = 0
   for _, l in ipairs(lines) do
     if l:match "^%s*$" then blank_count = blank_count + 1 end
@@ -270,11 +270,11 @@ test("loose list: blank lines between different marker types are kept (ul vs ol)
 end)
 
 test("loose list: blank lines between different bullet chars are kept (- vs *)", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "- item 1",
     "",
     "* item 2",
-  })
+  }
   local blank_count = 0
   for _, l in ipairs(lines) do
     if l:match "^%s*$" then blank_count = blank_count + 1 end
@@ -283,11 +283,11 @@ test("loose list: blank lines between different bullet chars are kept (- vs *)",
 end)
 
 test("loose list: blank lines between different ordered delimiters are kept (. vs ))", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "1. item 1",
     "",
     "1) item 2",
-  })
+  }
   local blank_count = 0
   for _, l in ipairs(lines) do
     if l:match "^%s*$" then blank_count = blank_count + 1 end
@@ -296,13 +296,13 @@ test("loose list: blank lines between different ordered delimiters are kept (. v
 end)
 
 test("loose list with checkboxes: blank lines collapsed", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "- [ ] todo 1",
     "",
     "- [x] done 1",
     "",
     "- [-] partial 1",
-  })
+  }
   local blank_count = 0
   for _, l in ipairs(lines) do
     if l:match "^%s*$" then blank_count = blank_count + 1 end
@@ -312,11 +312,11 @@ test("loose list with checkboxes: blank lines collapsed", function()
 end)
 
 test("tight list: no change", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "- item 1",
     "- item 2",
     "- item 3",
-  })
+  }
   assert_eq(#lines, 3, "tight list: should have 3 lines")
 end)
 
@@ -328,44 +328,44 @@ local function render_doc_full(input_lines, opts)
 end
 
 test("details: collapsed by default (no open attribute)", function()
-  local lines, folds = render_doc_full({
+  local lines, folds = render_doc_full {
     "<details>",
     "<summary>Title</summary>",
     "",
     "Body content",
     "",
     "</details>",
-  })
+  }
   -- Should show only the summary header, body is hidden
   assert_eq(#lines, 1, "collapsed details: should have 1 line (header only)")
   assert_eq(#folds, 1, "collapsed details: should have 1 fold entry")
   assert_eq(folds[1].collapsed, true, "collapsed details: fold should be collapsed")
   -- Header should contain the title
   local header = lines[1]
-  assert_eq(header:match("Title") ~= nil, true, "collapsed details: header should contain title")
+  assert_eq(header:match "Title" ~= nil, true, "collapsed details: header should contain title")
 end)
 
 test("details open: expanded by default with │ prefix", function()
-  local lines, folds = render_doc_full({
+  local lines, folds = render_doc_full {
     "<details open>",
     "<summary>Title</summary>",
     "",
     "Body content",
     "",
     "</details>",
-  })
+  }
   -- Should show header + blank + body content
   assert_eq(#folds, 1, "open details: should have 1 fold entry")
   assert_eq(folds[1].collapsed, false, "open details: fold should be expanded")
   -- Body should be visible with │ prefix
   local has_body = false
   for _, l in ipairs(lines) do
-    if l:match("│") and l:match("Body content") then has_body = true end
+    if l:match "│" and l:match "Body content" then has_body = true end
   end
   assert_eq(has_body, true, "open details: body should have │ prefix")
   -- Header should NOT have │ prefix
   local header = lines[1]
-  assert_eq(header:match("^│") == nil, true, "open details: header should not have │ prefix")
+  assert_eq(header:match "^│" == nil, true, "open details: header should not have │ prefix")
 end)
 
 test("details: fold_state overrides default", function()
@@ -380,43 +380,43 @@ test("details: fold_state overrides default", function()
   -- fold_state says src_idx 1 (the <details> line) is NOT collapsed
   local has_body = false
   for _, l in ipairs(lines) do
-    if l:match("Body content") then has_body = true end
+    if l:match "Body content" then has_body = true end
   end
   assert_eq(has_body, true, "fold_state override: body should be visible")
 end)
 
 test("details: no summary tag renders default 'Details' label", function()
-  local lines = render_doc_full({
+  local lines = render_doc_full {
     "<details open>",
     "Body without summary",
     "</details>",
-  })
+  }
   local has_details_label = false
   for _, l in ipairs(lines) do
-    if l:match("Details") then has_details_label = true end
+    if l:match "Details" then has_details_label = true end
   end
   assert_eq(has_details_label, true, "no summary: should use default 'Details' label")
 end)
 
 test("details: inline summary on details tag", function()
-  local lines, folds = render_doc_full({
+  local lines, folds = render_doc_full {
     "<details><summary>Inline Title</summary>",
     "",
     "Body",
     "",
     "</details>",
-  })
+  }
   assert_eq(#folds, 1, "inline summary: should have 1 fold")
-  assert_eq(lines[1]:match("Inline Title") ~= nil, true, "inline summary: header should contain title")
+  assert_eq(lines[1]:match "Inline Title" ~= nil, true, "inline summary: header should contain title")
 end)
 
 test("details: nested details depth tracking", function()
-  local lines = render_doc_full({
+  local lines = render_doc_full {
     "<details>",
     "<summary>Outer</summary>",
     "Outer body",
     "</details>",
-  })
+  }
   -- Collapsed: only header visible
   assert_eq(#lines, 1, "nested: outer collapsed should have 1 line")
 end)
@@ -424,7 +424,7 @@ end)
 -- HTML inline tag tests
 
 test("html: <b> renders as Bold", function()
-  local text, highlights = render("<b>bold text</b>")
+  local text, highlights = render "<b>bold text</b>"
   assert_eq(text, "bold text", "html b: text should have tags stripped")
   local has_bold = false
   for _, hl in ipairs(highlights) do
@@ -434,80 +434,80 @@ test("html: <b> renders as Bold", function()
 end)
 
 test("html: <strong> renders as Bold", function()
-  local text, highlights = render("<strong>bold</strong>")
+  local text, highlights = render "<strong>bold</strong>"
   assert_eq(text, "bold", "html strong: tags should be stripped")
   assert_eq(highlights[1].hl, "Bold", "html strong: should be Bold")
 end)
 
 test("html: <i> renders as Italic", function()
-  local text, highlights = render("<i>italic</i>")
+  local text, highlights = render "<i>italic</i>"
   assert_eq(text, "italic", "html i: tags should be stripped")
   assert_eq(highlights[1].hl, "Italic", "html i: should be Italic")
 end)
 
 test("html: <em> renders as Italic", function()
-  local text, highlights = render("<em>emphasis</em>")
+  local text, highlights = render "<em>emphasis</em>"
   assert_eq(text, "emphasis", "html em: tags should be stripped")
   assert_eq(highlights[1].hl, "Italic", "html em: should be Italic")
 end)
 
 test("html: <code> renders as MdRenderInlineCode", function()
-  local text, highlights = render("<code>code</code>")
+  local text, highlights = render "<code>code</code>"
   assert_eq(text, "code", "html code: tags should be stripped")
   assert_eq(highlights[1].hl, "MdRenderInlineCode", "html code: should be MdRenderInlineCode")
 end)
 
 test("html: <s> renders as strikethrough", function()
-  local text, highlights = render("<s>deleted</s>")
+  local text, highlights = render "<s>deleted</s>"
   assert_eq(text, "deleted", "html s: tags should be stripped")
   assert_eq(highlights[1].hl, "DiagnosticDeprecated", "html s: should be DiagnosticDeprecated")
 end)
 
 test("html: <del> renders as strikethrough", function()
-  local text, highlights = render("<del>removed</del>")
+  local text, highlights = render "<del>removed</del>"
   assert_eq(text, "removed", "html del: tags should be stripped")
   assert_eq(highlights[1].hl, "DiagnosticDeprecated", "html del: should be DiagnosticDeprecated")
 end)
 
 test("html: <u> renders as Underlined", function()
-  local text, highlights = render("<u>underline</u>")
+  local text, highlights = render "<u>underline</u>"
   assert_eq(text, "underline", "html u: tags should be stripped")
   assert_eq(highlights[1].hl, "Underlined", "html u: should be Underlined")
 end)
 
 test("html: <mark> renders as MdRenderHighlight", function()
-  local text, highlights = render("<mark>highlighted</mark>")
+  local text, highlights = render "<mark>highlighted</mark>"
   assert_eq(text, "highlighted", "html mark: tags should be stripped")
   assert_eq(highlights[1].hl, "MdRenderHighlight", "html mark: should be MdRenderHighlight")
 end)
 
 test("html: <kbd> renders as Special", function()
-  local text, highlights = render("<kbd>Ctrl+C</kbd>")
+  local text, highlights = render "<kbd>Ctrl+C</kbd>"
   assert_eq(text, "Ctrl+C", "html kbd: tags should be stripped")
   assert_eq(highlights[1].hl, "Special", "html kbd: should be Special")
 end)
 
 test("html: <sub> strips tags without highlight", function()
-  local text, highlights = render("<sub>subscript</sub>")
+  local text, highlights = render "<sub>subscript</sub>"
   assert_eq(text, "subscript", "html sub: tags should be stripped")
   assert_eq(#highlights, 0, "html sub: should have no highlights")
 end)
 
 test("html: <sup> strips tags without highlight", function()
-  local text, highlights = render("<sup>superscript</sup>")
+  local text, highlights = render "<sup>superscript</sup>"
   assert_eq(text, "superscript", "html sup: tags should be stripped")
   assert_eq(#highlights, 0, "html sup: should have no highlights")
 end)
 
 test("html: <a href> renders as link", function()
-  local text, highlights, _ = render('<a href="https://example.com">click here</a>')
+  local text, highlights, _ = render '<a href="https://example.com">click here</a>'
   assert_eq(text, "click here", "html a: tags should be stripped")
   assert_eq(highlights[1].hl, "Underlined", "html a: should be Underlined")
 end)
 
 test("html: <a href> produces link metadata", function()
   local Markdown = require "md-render.markdown"
-  local text, _, links = Markdown.render('<a href="https://example.com">link text</a>')
+  local text, _, links = Markdown.render '<a href="https://example.com">link text</a>'
   assert_eq(text, "link text", "html a link: text")
   assert_eq(#links, 1, "html a link: should have 1 link")
   assert_eq(links[1].url, "https://example.com", "html a link: url should match")
@@ -515,21 +515,21 @@ end)
 
 test("html: <img> renders as image display", function()
   local Markdown = require "md-render.markdown"
-  local text, highlights, links = Markdown.render('<img src="photo.png" alt="My Photo">')
-  assert(text:find("My Photo"), "html img: should contain alt text")
-  assert(text:find("My Photo"), "html img: should contain image display text")
+  local text, highlights, links = Markdown.render '<img src="photo.png" alt="My Photo">'
+  assert(text:find "My Photo", "html img: should contain alt text")
+  assert(text:find "My Photo", "html img: should contain image display text")
   assert_eq(#links, 1, "html img: should have 1 link")
   assert_eq(links[1].url, "photo.png", "html img: link url should be src")
 end)
 
 test("html: <img> without alt shows filename", function()
   local Markdown = require "md-render.markdown"
-  local text = Markdown.render('<img src="/path/to/image.jpg">')
-  assert(text:find("image.jpg"), "html img no alt: should show filename")
+  local text = Markdown.render '<img src="/path/to/image.jpg">'
+  assert(text:find "image.jpg", "html img no alt: should show filename")
 end)
 
 test("html: unknown tags are kept with Comment highlight", function()
-  local text, highlights = render("<div>content</div>")
+  local text, highlights = render "<div>content</div>"
   assert_eq(text, "<div>content</div>", "html unknown: tags should be kept")
   local found_open = false
   local found_close = false
@@ -542,7 +542,7 @@ test("html: unknown tags are kept with Comment highlight", function()
 end)
 
 test("html: self-closing unknown tags are kept with Comment highlight", function()
-  local text, highlights = render("before<br/>after")
+  local text, highlights = render "before<br/>after"
   assert_eq(text, "before<br/>after", "html br: tag should be kept")
   local found = false
   for _, h in ipairs(highlights) do
@@ -552,22 +552,22 @@ test("html: self-closing unknown tags are kept with Comment highlight", function
 end)
 
 test("html: inline comments are stripped", function()
-  local text = render("before<!-- comment -->after")
+  local text = render "before<!-- comment -->after"
   assert_eq(text, "beforeafter", "html comment: inline comment should be removed")
 end)
 
 test("html: standalone comment line is stripped", function()
-  local text = render("<!-- this is a comment -->")
+  local text = render "<!-- this is a comment -->"
   assert_eq(text, "", "html comment: standalone comment should be removed")
 end)
 
 test("html: tags inside backticks are preserved", function()
-  local text = render("`<b>not bold</b>`")
-  assert(text:find("<b>"), "html in backtick: <b> should be preserved")
+  local text = render "`<b>not bold</b>`"
+  assert(text:find "<b>", "html in backtick: <b> should be preserved")
 end)
 
 test("html: mixed markdown and html", function()
-  local text, highlights = render("**bold** and <i>italic</i>")
+  local text, highlights = render "**bold** and <i>italic</i>"
   assert_eq(text, "bold and italic", "mixed: markers and tags stripped")
   local has_bold, has_italic = false, false
   for _, hl in ipairs(highlights) do
@@ -579,7 +579,7 @@ test("html: mixed markdown and html", function()
 end)
 
 test("html: <strike> renders as strikethrough", function()
-  local text, highlights = render("<strike>old</strike>")
+  local text, highlights = render "<strike>old</strike>"
   assert_eq(text, "old", "html strike: tags should be stripped")
   assert_eq(highlights[1].hl, "DiagnosticDeprecated", "html strike: should be DiagnosticDeprecated")
 end)
@@ -587,39 +587,39 @@ end)
 -- render_document HTML block-level tests
 
 test("html: <h1> renders as heading", function()
-  local lines = render_doc({ "<h1>Title</h1>" })
+  local lines = render_doc { "<h1>Title</h1>" }
   assert_eq(#lines, 1, "html h1: should have 1 line")
-  assert(lines[1]:find("Title"), "html h1: should contain title text")
+  assert(lines[1]:find "Title", "html h1: should contain title text")
 end)
 
 test("html: <h3> renders as heading level 3", function()
-  local lines = render_doc({ "<h3>Section</h3>" })
-  assert(lines[1]:find("Section"), "html h3: should contain section text")
+  local lines = render_doc { "<h3>Section</h3>" }
+  assert(lines[1]:find "Section", "html h3: should contain section text")
 end)
 
 test("html: <hr> renders as horizontal rule", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "above",
     "<hr>",
     "below",
-  })
+  }
   local has_rule = false
   for _, l in ipairs(lines) do
-    if l:match("─") then has_rule = true end
+    if l:match "─" then has_rule = true end
   end
   assert_eq(has_rule, true, "html hr: should have horizontal rule")
   assert_eq(#lines, 5, "html hr: should have 5 lines (text + blank + rule + blank + text)")
 end)
 
 test("html: <hr/> self-closing renders as rule", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "above",
     "<hr/>",
     "below",
-  })
+  }
   local has_rule = false
   for _, l in ipairs(lines) do
-    if l:match("─") then has_rule = true end
+    if l:match "─" then has_rule = true end
   end
   assert_eq(has_rule, true, "html hr/: should have horizontal rule")
 end)
@@ -627,49 +627,49 @@ end)
 -- HTML inside <details> tests
 
 test("details: inline HTML tags work in body", function()
-  local lines = render_doc_full({
+  local lines = render_doc_full {
     "<details open>",
     "<summary>Info</summary>",
     "",
     "<b>bold text</b> inside details",
     "",
     "</details>",
-  })
+  }
   local has_body = false
   for _, l in ipairs(lines) do
-    if l:match("bold text") and l:match("│") then has_body = true end
+    if l:match "bold text" and l:match "│" then has_body = true end
   end
   assert_eq(has_body, true, "details inline html: body with <b> should have │ prefix")
 end)
 
 test("details: <h3> works in body", function()
-  local lines = render_doc_full({
+  local lines = render_doc_full {
     "<details open>",
     "<summary>Heading test</summary>",
     "",
     "<h3>Sub Section</h3>",
     "",
     "</details>",
-  })
+  }
   local has_heading = false
   for _, l in ipairs(lines) do
-    if l:match("Sub Section") and l:match("│") then has_heading = true end
+    if l:match "Sub Section" and l:match "│" then has_heading = true end
   end
   assert_eq(has_heading, true, "details h3: heading should have │ prefix")
 end)
 
 test("details: <hr> works in body with │ prefix", function()
-  local lines = render_doc_full({
+  local lines = render_doc_full {
     "<details open>",
     "<summary>Rule test</summary>",
     "",
     "<hr>",
     "",
     "</details>",
-  })
+  }
   local has_rule_with_prefix = false
   for _, l in ipairs(lines) do
-    if l:match("─") and l:match("│") then has_rule_with_prefix = true end
+    if l:match "─" and l:match "│" then has_rule_with_prefix = true end
   end
   assert_eq(has_rule_with_prefix, true, "details hr: rule should have │ prefix")
 end)
@@ -686,7 +686,7 @@ test("details: <a> link works in body", function()
   }, { max_width = 80, indent = "" })
   local has_link = false
   for _, l in ipairs(builder.lines) do
-    if l:match("click") and l:match("│") then has_link = true end
+    if l:match "click" and l:match "│" then has_link = true end
   end
   assert_eq(has_link, true, "details a: link text should have │ prefix")
   local has_link_meta = false
@@ -699,7 +699,7 @@ end)
 -- Nested HTML tag tests
 
 test("html nested: <b><i>text</i></b>", function()
-  local text, highlights = render("<b><i>text</i></b>")
+  local text, highlights = render "<b><i>text</i></b>"
   assert_eq(text, "text", "nested bi: tags should be stripped")
   local has_bold, has_italic = false, false
   for _, hl in ipairs(highlights) do
@@ -712,7 +712,7 @@ end)
 
 test("html nested: <a><b>text</b></a>", function()
   local Markdown = require "md-render.markdown"
-  local text, highlights, links = Markdown.render('<a href="https://example.com"><b>link</b></a>')
+  local text, highlights, links = Markdown.render '<a href="https://example.com"><b>link</b></a>'
   assert_eq(text, "link", "nested a-b: tags should be stripped")
   local has_bold, has_underlined = false, false
   for _, hl in ipairs(highlights) do
@@ -726,7 +726,7 @@ test("html nested: <a><b>text</b></a>", function()
 end)
 
 test("html nested: highlight positions are correct", function()
-  local text, highlights = render("before <b><i>inner</i></b> after")
+  local text, highlights = render "before <b><i>inner</i></b> after"
   assert_eq(text, "before inner after", "nested pos: text correct")
   for _, hl in ipairs(highlights) do
     if hl.hl == "Bold" then
@@ -743,57 +743,57 @@ end)
 -- Multi-line HTML tag tests
 
 test("html multiline: inline <b> spanning lines", function()
-  local lines = render_doc({ "<b>bold", "text</b>" })
+  local lines = render_doc { "<b>bold", "text</b>" }
   -- Should be joined into one line with bold
   local found = false
   for _, l in ipairs(lines) do
-    if l:match("bold text") then found = true end
+    if l:match "bold text" then found = true end
   end
   assert_eq(found, true, "multiline b: should join lines with space")
 end)
 
 test("html multiline: block <div> strips wrapper and renders content", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "<div>",
     "line one",
     "line two",
     "</div>",
-  })
+  }
   local has_content = false
   for _, l in ipairs(lines) do
-    if l:match("line one") or l:match("line two") then has_content = true end
+    if l:match "line one" or l:match "line two" then has_content = true end
   end
   assert_eq(has_content, true, "multiline div: inner content should be rendered")
   -- <div> wrapper tags should be stripped (not shown)
   local has_div = false
   for _, l in ipairs(lines) do
-    if l:match("<div>") then has_div = true end
+    if l:match "<div>" then has_div = true end
   end
   assert_eq(has_div, false, "multiline div: <div> tags should be stripped")
 end)
 
 test("html multiline: nested same-type block", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "<div>",
     "<div>inner</div>",
     "</div>",
-  })
+  }
   local has_inner = false
   for _, l in ipairs(lines) do
-    if l:match("inner") then has_inner = true end
+    if l:match "inner" then has_inner = true end
   end
   assert_eq(has_inner, true, "nested div: inner content should show")
 end)
 
 test("html multiline: <p> joins content", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "<p>",
     "Paragraph content here.",
     "</p>",
-  })
+  }
   local found = false
   for _, l in ipairs(lines) do
-    if l:match("Paragraph content") then found = true end
+    if l:match "Paragraph content" then found = true end
   end
   assert_eq(found, true, "multiline p: content should show")
 end)
@@ -803,16 +803,16 @@ test("html multiline: <h1> with img and links (neovim-style)", function()
   builder:render_document({
     '<h1 align="center">',
     '  <img src="https://example.com/logo.png" alt="Neovim">',
-    '',
+    "",
     '  <a href="https://neovim.io/doc/">Documentation</a> |',
     '  <a href="https://example.com/chat">Chat</a>',
-    '</h1>',
+    "</h1>",
   }, { max_width = 80, indent = "" })
   -- Image is split out from heading: image line(s) + heading line with links
   local all_text = table.concat(builder.lines, "\n")
-  assert(all_text:find("Neovim"), "h1 multiline: should contain Neovim (from img alt)")
-  assert(all_text:find("Documentation"), "h1 multiline: should contain Documentation")
-  assert(all_text:find("Chat"), "h1 multiline: should contain Chat")
+  assert(all_text:find "Neovim", "h1 multiline: should contain Neovim (from img alt)")
+  assert(all_text:find "Documentation", "h1 multiline: should contain Documentation")
+  assert(all_text:find "Chat", "h1 multiline: should contain Chat")
   -- Should have heading highlight
   local has_h1 = false
   for _, hl in ipairs(builder.highlights) do
@@ -839,106 +839,106 @@ test("html multiline: inline <b> has Bold highlight after join", function()
 end)
 
 test("html multiline: code block inside block element not broken", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "<div>",
     "```python",
     "print('hello')",
     "```",
     "</div>",
-  })
+  }
   local has_print = false
   for _, l in ipairs(lines) do
-    if l:match("print") then has_print = true end
+    if l:match "print" then has_print = true end
   end
   assert_eq(has_print, true, "div+code: code content should render")
 end)
 
 test("html multiline: tags inside code blocks not preprocessed", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "```",
     "<div>",
     "should stay",
     "</div>",
     "```",
-  })
+  }
   local has_div = false
   for _, l in ipairs(lines) do
-    if l:match("<div>") then has_div = true end
+    if l:match "<div>" then has_div = true end
   end
   assert_eq(has_div, true, "code block div: <div> should be preserved")
 end)
 
 test("html multiline: <div> with attributes", function()
-  local lines = render_doc({
+  local lines = render_doc {
     '<div class="note" id="foo">',
     "styled content",
     "</div>",
-  })
+  }
   local found = false
   for _, l in ipairs(lines) do
-    if l:match("styled content") then found = true end
+    if l:match "styled content" then found = true end
   end
   assert_eq(found, true, "div attrs: content should show")
   -- Tags are now kept with Comment highlight, not stripped
 end)
 
 test("html multiline: unclosed tag outputs lines as-is", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "<b>unclosed",
     "still here",
-  })
+  }
   assert_eq(#lines >= 1, true, "unclosed: should output something")
 end)
 
 test("html multiline: <div> content on opening tag line", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "<div>first line content",
     "second line",
     "</div>",
-  })
+  }
   local has_first, has_second = false, false
   for _, l in ipairs(lines) do
-    if l:match("first line content") then has_first = true end
-    if l:match("second line") then has_second = true end
+    if l:match "first line content" then has_first = true end
+    if l:match "second line" then has_second = true end
   end
   assert_eq(has_first, true, "div inline open: first line content")
   assert_eq(has_second, true, "div inline open: second line content")
 end)
 
 test("html block comment: single-line comment is skipped", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "before",
     "<!-- this is a comment -->",
     "after",
-  })
+  }
   for _, l in ipairs(lines) do
-    assert_eq(l:match("comment"), nil, "html block comment: should not show comment")
+    assert_eq(l:match "comment", nil, "html block comment: should not show comment")
   end
   local has_before, has_after = false, false
   for _, l in ipairs(lines) do
-    if l:match("before") then has_before = true end
-    if l:match("after") then has_after = true end
+    if l:match "before" then has_before = true end
+    if l:match "after" then has_after = true end
   end
   assert_eq(has_before, true, "html block comment: before should show")
   assert_eq(has_after, true, "html block comment: after should show")
 end)
 
 test("html block comment: multi-line comment is skipped", function()
-  local lines = render_doc({
+  local lines = render_doc {
     "before",
     "<!-- multi",
     "line comment",
     "-->",
     "after",
-  })
+  }
   for _, l in ipairs(lines) do
-    assert_eq(l:match("multi"), nil, "html multi comment: should not show first line")
-    assert_eq(l:match("line comment"), nil, "html multi comment: should not show middle")
+    assert_eq(l:match "multi", nil, "html multi comment: should not show first line")
+    assert_eq(l:match "line comment", nil, "html multi comment: should not show middle")
   end
   local has_before, has_after = false, false
   for _, l in ipairs(lines) do
-    if l:match("before") then has_before = true end
-    if l:match("after") then has_after = true end
+    if l:match "before" then has_before = true end
+    if l:match "after" then has_after = true end
   end
   assert_eq(has_before, true, "html multi comment: before should show")
   assert_eq(has_after, true, "html multi comment: after should show")
@@ -946,7 +946,7 @@ end)
 
 test("link with inline code: underline covers full text", function()
   local Markdown = require "md-render.markdown"
-  local text, highlights, links = Markdown.render("[`async.wrap`](#31-asyncwrap)")
+  local text, highlights, links = Markdown.render "[`async.wrap`](#31-asyncwrap)"
   assert_eq(text, "async.wrap", "code-in-link: text should strip backticks and link syntax")
   -- Find Underlined highlight
   local underline
@@ -991,9 +991,7 @@ test("multiple code spans with link: underline position correct", function()
   for _, hl in ipairs(highlights) do
     if hl.hl == "Underlined" then
       local covered = text:sub(hl.col + 1, hl.end_col)
-      if covered:find("target") then
-        target_hl = hl
-      end
+      if covered:find "target" then target_hl = hl end
     end
   end
   assert_eq(target_hl ~= nil, true, "multi-code-link: should have Underlined for target.func")
@@ -1005,6 +1003,4 @@ end)
 
 -- Print summary
 print(string.format("\n%d passed, %d failed", pass_count, fail_count))
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/toggle_test.lua
+++ b/tests/toggle_test.lua
@@ -53,9 +53,7 @@ local function setup_md_buffer(lines)
 end
 
 local function cleanup_buffer(buf)
-  if vim.api.nvim_buf_is_valid(buf) then
-    pcall(vim.api.nvim_buf_delete, buf, { force = true })
-  end
+  if vim.api.nvim_buf_is_valid(buf) then pcall(vim.api.nvim_buf_delete, buf, { force = true }) end
 end
 
 local function clear_win_state(win)
@@ -67,7 +65,9 @@ end
 -- window, so nvim_get_current_win() does NOT identify the new split.
 local function find_new_win(before_wins)
   local before_set = {}
-  for _, w in ipairs(before_wins) do before_set[w] = true end
+  for _, w in ipairs(before_wins) do
+    before_set[w] = true
+  end
   for _, w in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
     if not before_set[w] then return w end
   end
@@ -78,7 +78,7 @@ end
 -- Test 1: source → render swaps the buffer in the same window
 -- ----------------------------------------------------------------------
 test("source → render swaps buffer in the same window", function()
-  local source = setup_md_buffer({ "# Hello", "", "Some text" })
+  local source = setup_md_buffer { "# Hello", "", "Some text" }
   local win = vim.api.nvim_get_current_win()
 
   preview.toggle()
@@ -108,12 +108,12 @@ end)
 -- Test 2: render → source swaps back to the original buffer
 -- ----------------------------------------------------------------------
 test("render → source swaps back to original buffer", function()
-  local source = setup_md_buffer({ "# Hello", "", "Some text" })
+  local source = setup_md_buffer { "# Hello", "", "Some text" }
   local win = vim.api.nvim_get_current_win()
 
-  preview.toggle()  -- → render
+  preview.toggle() -- → render
   local render_buf = vim.api.nvim_win_get_buf(win)
-  preview.toggle()  -- → source
+  preview.toggle() -- → source
 
   assert_eq(vim.api.nvim_win_get_buf(win), source, "should be back on source buffer")
 
@@ -128,7 +128,7 @@ end)
 -- Test 3: round-trip reuses the same render buffer (cached session)
 -- ----------------------------------------------------------------------
 test("round-trip reuses the same render buffer", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
   preview.toggle()
@@ -146,7 +146,7 @@ end)
 -- Test 4: cursor position survives source → render → source
 -- ----------------------------------------------------------------------
 test("cursor position survives round-trip via source_line_map", function()
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "# Heading 1",
     "",
     "First paragraph.",
@@ -156,7 +156,7 @@ test("cursor position survives round-trip via source_line_map", function()
     "Second paragraph.",
     "",
     "Last line.",
-  })
+  }
   local win = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_cursor(win, { 7, 0 }) -- "Second paragraph."
 
@@ -166,10 +166,7 @@ test("cursor position survives round-trip via source_line_map", function()
   local final_line = vim.api.nvim_win_get_cursor(win)[1]
   -- Source line 7 should round-trip back close to itself (allow ±1 for mapping
   -- artifacts on heading-adjacent lines).
-  assert_true(
-    math.abs(final_line - 7) <= 2,
-    "cursor should return near source line 7 (got " .. final_line .. ")"
-  )
+  assert_true(math.abs(final_line - 7) <= 2, "cursor should return near source line 7 (got " .. final_line .. ")")
 
   cleanup_buffer(source)
 end)
@@ -200,7 +197,7 @@ end)
 -- Test 6: BufWipeout on source clears the cached session
 -- ----------------------------------------------------------------------
 test("BufWipeout on source clears cached session", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
 
   preview.toggle()
   assert_true(preview._toggle_sessions[source] ~= nil, "session should be cached")
@@ -216,23 +213,25 @@ end)
 -- Test 7: source change is reflected on next toggle
 -- ----------------------------------------------------------------------
 test("source change is reflected on next source → render toggle", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
   preview.toggle()
   local first_render = vim.api.nvim_win_get_buf(win)
   local first_lines = vim.api.nvim_buf_get_lines(first_render, 0, -1, false)
 
-  preview.toggle()  -- back to source
+  preview.toggle() -- back to source
   vim.api.nvim_buf_set_lines(source, 0, -1, false, { "# Hello", "", "Added paragraph." })
 
-  preview.toggle()  -- back to render — should reflect new source
+  preview.toggle() -- back to render — should reflect new source
   local render_buf = vim.api.nvim_win_get_buf(win)
   local new_lines = vim.api.nvim_buf_get_lines(render_buf, 0, -1, false)
 
   -- Line count should have grown (new paragraph added)
-  assert_true(#new_lines > #first_lines, "render content should reflect source changes (lines: "
-    .. #first_lines .. " → " .. #new_lines .. ")")
+  assert_true(
+    #new_lines > #first_lines,
+    "render content should reflect source changes (lines: " .. #first_lines .. " → " .. #new_lines .. ")"
+  )
 
   cleanup_buffer(source)
 end)
@@ -241,7 +240,7 @@ end)
 -- Test 8: live update autocmds are installed for the source buffer
 -- ----------------------------------------------------------------------
 test("live update autocmds are installed on first toggle", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   preview.toggle()
 
   local autocmds = vim.api.nvim_get_autocmds {
@@ -249,7 +248,9 @@ test("live update autocmds are installed on first toggle", function()
     buffer = source,
   }
   local events = {}
-  for _, ac in ipairs(autocmds) do events[ac.event] = true end
+  for _, ac in ipairs(autocmds) do
+    events[ac.event] = true
+  end
 
   assert_true(events.TextChanged, "TextChanged autocmd should be registered")
   assert_true(events.TextChangedI, "TextChangedI autocmd should be registered")
@@ -264,10 +265,10 @@ end)
 -- Test 9: live rebuild fires after debounce when render is visible
 -- ----------------------------------------------------------------------
 test("live rebuild fires after debounce when render is visible", function()
-  local source = setup_md_buffer({ "# Hello", "", "para" })
+  local source = setup_md_buffer { "# Hello", "", "para" }
   local source_win = vim.api.nvim_get_current_win()
 
-  preview.toggle()  -- render in source_win
+  preview.toggle() -- render in source_win
   local render_buf = vim.api.nvim_win_get_buf(source_win)
   local before_lines = #vim.api.nvim_buf_get_lines(render_buf, 0, -1, false)
 
@@ -279,7 +280,9 @@ test("live rebuild fires after debounce when render is visible", function()
   vim.api.nvim_buf_set_lines(source, -1, -1, false, { "", "appended paragraph" })
   preview._schedule_live_rebuild(preview._toggle_sessions[source])
 
-  vim.wait(300, function() return false end)
+  vim.wait(300, function()
+    return false
+  end)
 
   local after_lines = #vim.api.nvim_buf_get_lines(render_buf, 0, -1, false)
   assert_true(
@@ -295,11 +298,11 @@ end)
 -- Test 10: hidden render → edit only marks dirty (no rebuild, no timer)
 -- ----------------------------------------------------------------------
 test("hidden render → edit sets dirty without scheduling a rebuild", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
-  preview.toggle()  -- → render
-  preview.toggle()  -- → source (render now hidden)
+  preview.toggle() -- → render
+  preview.toggle() -- → source (render now hidden)
 
   local session = preview._toggle_sessions[source]
   assert_true(session ~= nil, "session should exist")
@@ -312,7 +315,9 @@ test("hidden render → edit sets dirty without scheduling a rebuild", function(
   assert_true(session._debounce_timer == nil, "no debounce timer should be running")
 
   -- Wait past the debounce window to be extra sure nothing fires
-  vim.wait(250, function() return false end)
+  vim.wait(250, function()
+    return false
+  end)
   assert_true(session._debounce_timer == nil, "still no debounce timer after wait")
 
   -- Re-toggle should consume dirty and rebuild
@@ -323,7 +328,10 @@ test("hidden render → edit sets dirty without scheduling a rebuild", function(
   local lines = vim.api.nvim_buf_get_lines(render_buf, 0, -1, false)
   local found = false
   for _, l in ipairs(lines) do
-    if l:find("new line", 1, true) then found = true; break end
+    if l:find("new line", 1, true) then
+      found = true
+      break
+    end
   end
   assert_true(found, "edited content should appear after re-toggle")
 
@@ -336,12 +344,12 @@ end)
 -- the stale content. Regression test for issue #5.
 -- ----------------------------------------------------------------------
 test("re-entering dirty render buf via :buffer rebuilds stale content", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
-  preview.toggle()  -- → render
+  preview.toggle() -- → render
   local render_buf = vim.api.nvim_win_get_buf(win)
-  preview.toggle()  -- → source (render now hidden)
+  preview.toggle() -- → source (render now hidden)
 
   local session = preview._toggle_sessions[source]
   assert_true(session ~= nil, "session should exist")
@@ -359,7 +367,10 @@ test("re-entering dirty render buf via :buffer rebuilds stale content", function
   local lines = vim.api.nvim_buf_get_lines(render_buf, 0, -1, false)
   local found = false
   for _, l in ipairs(lines) do
-    if l:find("fresh after hide", 1, true) then found = true; break end
+    if l:find("fresh after hide", 1, true) then
+      found = true
+      break
+    end
   end
   assert_true(found, "edited content should appear after re-entering render buf")
 
@@ -370,10 +381,10 @@ end)
 -- Test 11: rapid edits coalesce into a single rebuild via debounce
 -- ----------------------------------------------------------------------
 test("rapid edits coalesce into a single rebuild", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local source_win = vim.api.nvim_get_current_win()
 
-  preview.toggle()  -- render in source_win
+  preview.toggle() -- render in source_win
   vim.cmd "vsplit"
   local edit_win = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_buf(edit_win, source)
@@ -390,12 +401,18 @@ test("rapid edits coalesce into a single rebuild", function()
   for i = 1, 5 do
     vim.api.nvim_buf_set_lines(source, -1, -1, false, { "edit " .. i })
     preview._schedule_live_rebuild(session)
-    vim.wait(20, function() return false end)
+    vim.wait(20, function()
+      return false
+    end)
   end
 
   -- Wait for the debounce to fire (last edit + 150ms + slack)
-  vim.wait(300, function() return rebuild_count > 0 end)
-  vim.wait(50, function() return false end)
+  vim.wait(300, function()
+    return rebuild_count > 0
+  end)
+  vim.wait(50, function()
+    return false
+  end)
 
   assert_eq(rebuild_count, 1, "5 rapid edits should coalesce into exactly 1 rebuild")
 
@@ -408,7 +425,7 @@ end)
 -- Test 12: BufWipeout cleanly stops a pending debounce timer
 -- ----------------------------------------------------------------------
 test("BufWipeout stops pending debounce timer cleanly", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   preview.toggle()
   vim.cmd "vsplit"
   vim.api.nvim_win_set_buf(0, source)
@@ -422,7 +439,9 @@ test("BufWipeout stops pending debounce timer cleanly", function()
   -- Wait past the original 150ms — if the timer wasn't stopped, the deferred
   -- callback would fire on a wiped buffer and could throw. The assertion below
   -- will only succeed if cleanup ran.
-  vim.wait(250, function() return false end)
+  vim.wait(250, function()
+    return false
+  end)
 
   assert_true(preview._toggle_sessions[source] == nil, "session should be cleared")
 end)
@@ -432,18 +451,22 @@ end)
 -- ----------------------------------------------------------------------
 test("live rebuild preserves render window topline", function()
   local lines = {}
-  for i = 1, 100 do table.insert(lines, "line " .. i) end
+  for i = 1, 100 do
+    table.insert(lines, "line " .. i)
+  end
   local source = setup_md_buffer(lines)
   local source_win = vim.api.nvim_get_current_win()
 
-  preview.toggle()  -- render in source_win
+  preview.toggle() -- render in source_win
   local render_win = source_win
 
   -- Scroll the render window so topline > 1
   vim.api.nvim_win_call(render_win, function()
     vim.fn.winrestview { topline = 50, lnum = 60 }
   end)
-  local before = vim.api.nvim_win_call(render_win, function() return vim.fn.winsaveview() end)
+  local before = vim.api.nvim_win_call(render_win, function()
+    return vim.fn.winsaveview()
+  end)
 
   -- Edit source from a separate window (prepend a line)
   vim.cmd "vsplit"
@@ -451,9 +474,13 @@ test("live rebuild preserves render window topline", function()
   vim.api.nvim_win_set_buf(edit_win, source)
   vim.api.nvim_buf_set_lines(source, 0, 0, false, { "prepended" })
   preview._schedule_live_rebuild(preview._toggle_sessions[source])
-  vim.wait(300, function() return false end)
+  vim.wait(300, function()
+    return false
+  end)
 
-  local after = vim.api.nvim_win_call(render_win, function() return vim.fn.winsaveview() end)
+  local after = vim.api.nvim_win_call(render_win, function()
+    return vim.fn.winsaveview()
+  end)
   assert_true(
     math.abs(after.topline - before.topline) <= 5,
     "topline should be ~preserved (was " .. before.topline .. ", now " .. after.topline .. ")"
@@ -467,7 +494,7 @@ end)
 -- Test 13a: render buffer is named after the source for statusline display
 -- ----------------------------------------------------------------------
 test("render buffer name has [render] suffix", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local source_name = vim.api.nvim_buf_get_name(source)
   preview.toggle()
   local render_buf = vim.api.nvim_win_get_buf(0)
@@ -482,7 +509,7 @@ end)
 -- Test 13b: BufWriteCmd is registered on the render buffer to forward :w
 -- ----------------------------------------------------------------------
 test("BufWriteCmd is registered on render buffer to forward :w", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   preview.toggle()
   local render_buf = vim.api.nvim_win_get_buf(0)
 
@@ -499,7 +526,7 @@ end)
 -- Test 14: auto_on swaps to render and sets b:md_render_auto
 -- ----------------------------------------------------------------------
 test("auto_on flips to render and marks the buffer", function()
-  local source = setup_md_buffer({ "# Hello", "", "para" })
+  local source = setup_md_buffer { "# Hello", "", "para" }
   local win = vim.api.nvim_get_current_win()
 
   preview.auto_on()
@@ -517,7 +544,7 @@ end)
 -- driven by buffer-local keymaps on the render buffer instead)
 -- ----------------------------------------------------------------------
 test("auto_on registers InsertLeave autocmd", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   preview.auto_on()
 
   local autocmds = vim.api.nvim_get_autocmds {
@@ -525,7 +552,9 @@ test("auto_on registers InsertLeave autocmd", function()
     buffer = source,
   }
   local events = {}
-  for _, ac in ipairs(autocmds) do events[ac.event] = true end
+  for _, ac in ipairs(autocmds) do
+    events[ac.event] = true
+  end
 
   assert_true(events.InsertLeave, "InsertLeave autocmd should be registered")
   assert_false(events.InsertEnter, "InsertEnter autocmd should NOT be registered (handled via keymap)")
@@ -538,7 +567,7 @@ end)
 -- Test 15b: auto_on installs Insert-entry keymaps on the render buffer
 -- ----------------------------------------------------------------------
 test("auto_on installs i/I/a/A/o/O keymaps on render buffer", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
   preview.auto_on()
@@ -546,9 +575,11 @@ test("auto_on installs i/I/a/A/o/O keymaps on render buffer", function()
 
   local keymaps = vim.api.nvim_buf_get_keymap(render_buf, "n")
   local mapped = {}
-  for _, km in ipairs(keymaps) do mapped[km.lhs] = true end
+  for _, km in ipairs(keymaps) do
+    mapped[km.lhs] = true
+  end
 
-  for _, key in ipairs({ "i", "I", "a", "A", "o", "O" }) do
+  for _, key in ipairs { "i", "I", "a", "A", "o", "O" } do
     assert_true(mapped[key], "key '" .. key .. "' should be mapped on render buf")
   end
 
@@ -556,9 +587,11 @@ test("auto_on installs i/I/a/A/o/O keymaps on render buffer", function()
 
   local keymaps_after = vim.api.nvim_buf_get_keymap(render_buf, "n")
   local mapped_after = {}
-  for _, km in ipairs(keymaps_after) do mapped_after[km.lhs] = true end
+  for _, km in ipairs(keymaps_after) do
+    mapped_after[km.lhs] = true
+  end
 
-  for _, key in ipairs({ "i", "I", "a", "A", "o", "O" }) do
+  for _, key in ipairs { "i", "I", "a", "A", "o", "O" } do
     assert_false(mapped_after[key], "key '" .. key .. "' should be removed after auto_off")
   end
 
@@ -569,15 +602,17 @@ end)
 -- Test 16: schedule_auto_transition("source") flips render → source after debounce
 -- ----------------------------------------------------------------------
 test("auto-transition to source swaps render → source after 50ms", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
-  preview.auto_on()  -- now on render
+  preview.auto_on() -- now on render
   local rendered = vim.api.nvim_win_get_buf(win)
   assert_false(rendered == source, "should start on render")
 
   preview._schedule_auto_transition(source, "source")
-  vim.wait(120, function() return vim.api.nvim_win_get_buf(win) == source end)
+  vim.wait(120, function()
+    return vim.api.nvim_win_get_buf(win) == source
+  end)
 
   assert_eq(vim.api.nvim_win_get_buf(win), source, "should be back on source after debounce")
 
@@ -589,16 +624,20 @@ end)
 -- Test 17: schedule_auto_transition("render") flips source → render after debounce
 -- ----------------------------------------------------------------------
 test("auto-transition to render swaps source → render after 50ms", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
-  preview.auto_on()                                 -- render
+  preview.auto_on() -- render
   preview._schedule_auto_transition(source, "source")
-  vim.wait(120, function() return vim.api.nvim_win_get_buf(win) == source end)
+  vim.wait(120, function()
+    return vim.api.nvim_win_get_buf(win) == source
+  end)
   assert_eq(vim.api.nvim_win_get_buf(win), source, "precondition: source")
 
   preview._schedule_auto_transition(source, "render")
-  vim.wait(120, function() return vim.api.nvim_win_get_buf(win) ~= source end)
+  vim.wait(120, function()
+    return vim.api.nvim_win_get_buf(win) ~= source
+  end)
 
   assert_false(vim.api.nvim_win_get_buf(win) == source, "should be back on render after debounce")
 
@@ -610,7 +649,7 @@ end)
 -- Test 18: auto_off clears autocmds and restores source display
 -- ----------------------------------------------------------------------
 test("auto_off clears autocmds and swaps render back to source", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
   preview.auto_on()
@@ -638,7 +677,7 @@ end)
 -- Test 18b: auto_toggle twice returns to the original (source, auto-off) state
 -- ----------------------------------------------------------------------
 test("auto_toggle twice returns to original source/auto-off state", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
   assert_eq(vim.api.nvim_win_get_buf(win), source, "precondition: source")
@@ -659,7 +698,7 @@ end)
 -- Test 18c: auto_off leaves displayed mode unchanged when not showing render
 -- ----------------------------------------------------------------------
 test("auto_off does not swap when current window is not showing render", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local win = vim.api.nvim_get_current_win()
 
   preview.auto_on()
@@ -696,7 +735,7 @@ end)
 -- Test 20: split from source opens a horizontal split showing render
 -- ----------------------------------------------------------------------
 test("split from source opens a split showing render", function()
-  local source = setup_md_buffer({ "# Hello", "", "para" })
+  local source = setup_md_buffer { "# Hello", "", "para" }
   local source_win = vim.api.nvim_get_current_win()
   local before_wins = vim.api.nvim_tabpage_list_wins(0)
 
@@ -706,8 +745,7 @@ test("split from source opens a split showing render", function()
   assert_eq(#after_wins, #before_wins + 1, "should add exactly one window")
 
   -- split() returns focus to source; the new split is identified by diff.
-  assert_eq(vim.api.nvim_get_current_win(), source_win,
-    "focus should return to source window after split")
+  assert_eq(vim.api.nvim_get_current_win(), source_win, "focus should return to source window after split")
   local new_win = find_new_win(before_wins)
   assert_true(new_win ~= nil, "a new window should exist")
 
@@ -730,21 +768,22 @@ end)
 -- Test 21: vertical modifier produces a vertical split
 -- ----------------------------------------------------------------------
 test("split with mods.vertical = true produces a vertical split", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local source_win = vim.api.nvim_get_current_win()
   local before_height = vim.api.nvim_win_get_height(source_win)
   local before_width = vim.api.nvim_win_get_width(source_win)
 
   local before_wins = vim.api.nvim_tabpage_list_wins(0)
-  preview.split({ mods = { vertical = true } })
+  preview.split { mods = { vertical = true } }
 
   local new_win = find_new_win(before_wins)
   local after_height = vim.api.nvim_win_get_height(source_win)
   local after_width = vim.api.nvim_win_get_width(source_win)
-  assert_true(math.abs(after_height - before_height) <= 1,
-    "heights should be ~unchanged in a vertical split")
-  assert_true(after_width < before_width,
-    "source width should shrink (was " .. before_width .. ", now " .. after_width .. ")")
+  assert_true(math.abs(after_height - before_height) <= 1, "heights should be ~unchanged in a vertical split")
+  assert_true(
+    after_width < before_width,
+    "source width should shrink (was " .. before_width .. ", now " .. after_width .. ")"
+  )
 
   vim.api.nvim_win_close(new_win, true)
   cleanup_buffer(source)
@@ -754,7 +793,7 @@ end)
 -- Test 22: split from a render-mode window opens source in the new split
 -- ----------------------------------------------------------------------
 test("split from render window opens source in the new split", function()
-  local source = setup_md_buffer({ "# Hello", "", "body" })
+  local source = setup_md_buffer { "# Hello", "", "body" }
   local orig_win = vim.api.nvim_get_current_win()
 
   preview.toggle()
@@ -774,7 +813,7 @@ test("split from render window opens source in the new split", function()
   assert_false(has_state, "new source split should have no md_render_state")
 
   vim.api.nvim_win_close(new_win, true)
-  preview.toggle()  -- restore orig_win to source for clean teardown
+  preview.toggle() -- restore orig_win to source for clean teardown
   clear_win_state(orig_win)
   cleanup_buffer(source)
 end)
@@ -783,20 +822,19 @@ end)
 -- Test 23: split shares the cached toggle render buffer
 -- ----------------------------------------------------------------------
 test("split shares the cached toggle render buffer", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local orig_win = vim.api.nvim_get_current_win()
 
   preview.toggle()
   local toggle_render = vim.api.nvim_win_get_buf(orig_win)
-  preview.toggle()  -- back to source
+  preview.toggle() -- back to source
 
   local before_wins = vim.api.nvim_tabpage_list_wins(0)
   preview.split()
   local split_win = find_new_win(before_wins)
   local split_render = vim.api.nvim_win_get_buf(split_win)
 
-  assert_eq(split_render, toggle_render,
-    "split must reuse the cached render buffer from the toggle session")
+  assert_eq(split_render, toggle_render, "split must reuse the cached render buffer from the toggle session")
 
   vim.api.nvim_win_close(split_win, true)
   clear_win_state(orig_win)
@@ -807,7 +845,7 @@ end)
 -- Test 24: live update propagates to the split's render window
 -- ----------------------------------------------------------------------
 test("live update propagates to the split's render window", function()
-  local source = setup_md_buffer({ "# Hello", "", "para" })
+  local source = setup_md_buffer { "# Hello", "", "para" }
   local source_win = vim.api.nvim_get_current_win()
 
   local before_wins = vim.api.nvim_tabpage_list_wins(0)
@@ -821,12 +859,15 @@ test("live update propagates to the split's render window", function()
   vim.api.nvim_buf_set_lines(source, -1, -1, false, { "", "appended paragraph" })
   preview._schedule_live_rebuild(preview._toggle_sessions[source])
 
-  vim.wait(300, function() return false end)
+  vim.wait(300, function()
+    return false
+  end)
 
   local after_lines = #vim.api.nvim_buf_get_lines(render_buf, 0, -1, false)
-  assert_true(after_lines > before_lines,
-    "render in split should grow after live update (was "
-      .. before_lines .. ", now " .. after_lines .. ")")
+  assert_true(
+    after_lines > before_lines,
+    "render in split should grow after live update (was " .. before_lines .. ", now " .. after_lines .. ")"
+  )
 
   vim.api.nvim_win_close(split_win, true)
   cleanup_buffer(source)
@@ -836,7 +877,7 @@ end)
 -- Test 25: closing split window keeps render buf alive; toggle still works
 -- ----------------------------------------------------------------------
 test("closing split window keeps render buf alive; subsequent toggle works", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local source_win = vim.api.nvim_get_current_win()
 
   local before_wins = vim.api.nvim_tabpage_list_wins(0)
@@ -846,17 +887,18 @@ test("closing split window keeps render buf alive; subsequent toggle works", fun
 
   vim.api.nvim_win_close(split_win, true)
 
-  assert_true(vim.api.nvim_buf_is_valid(render_buf),
-    "render buf should outlive the split window (bufhidden=hide)")
-  assert_true(preview._toggle_sessions[source] ~= nil,
-    "session should remain cached for the source")
+  assert_true(vim.api.nvim_buf_is_valid(render_buf), "render buf should outlive the split window (bufhidden=hide)")
+  assert_true(preview._toggle_sessions[source] ~= nil, "session should remain cached for the source")
 
   vim.api.nvim_set_current_win(source_win)
   preview.toggle()
-  assert_eq(vim.api.nvim_win_get_buf(source_win), render_buf,
-    "toggle should reuse the same render buf after split close")
+  assert_eq(
+    vim.api.nvim_win_get_buf(source_win),
+    render_buf,
+    "toggle should reuse the same render buf after split close"
+  )
 
-  preview.toggle()  -- back to source for clean teardown
+  preview.toggle() -- back to source for clean teardown
   clear_win_state(source_win)
   cleanup_buffer(source)
 end)
@@ -866,18 +908,18 @@ end)
 -- restores them on render -> source
 -- ----------------------------------------------------------------------
 test("toggle hides number/relativenumber/list and restores them", function()
-  local source = setup_md_buffer({ "# Hello", "", "body" })
+  local source = setup_md_buffer { "# Hello", "", "body" }
   local win = vim.api.nvim_get_current_win()
   vim.wo[win].number = true
   vim.wo[win].relativenumber = true
   vim.wo[win].list = true
 
-  preview.toggle()  -- source -> render
+  preview.toggle() -- source -> render
   assert_false(vim.wo[win].number, "render: number off")
   assert_false(vim.wo[win].relativenumber, "render: relativenumber off")
   assert_false(vim.wo[win].list, "render: list off")
 
-  preview.toggle()  -- render -> source
+  preview.toggle() -- render -> source
   assert_true(vim.wo[win].number, "source: number restored")
   assert_true(vim.wo[win].relativenumber, "source: relativenumber restored")
   assert_true(vim.wo[win].list, "source: list restored")
@@ -891,7 +933,7 @@ end)
 -- keeps its original options
 -- ----------------------------------------------------------------------
 test("split render window hides nu/rnu/list; source unchanged", function()
-  local source = setup_md_buffer({ "# Hello" })
+  local source = setup_md_buffer { "# Hello" }
   local source_win = vim.api.nvim_get_current_win()
   vim.wo[source_win].number = true
   vim.wo[source_win].relativenumber = true
@@ -936,7 +978,7 @@ end)
 -- Test 27: source CursorMoved syncs render cursor to the corresponding line
 -- ----------------------------------------------------------------------
 test("source cursor move syncs render window cursor", function()
-  local source = setup_md_buffer({ "# Heading", "", "para 1", "", "para 2" })
+  local source = setup_md_buffer { "# Heading", "", "para 1", "", "para 2" }
   local source_win = vim.api.nvim_get_current_win()
 
   local before_wins = vim.api.nvim_tabpage_list_wins(0)
@@ -955,8 +997,7 @@ test("source cursor move syncs render window cursor", function()
   local expected = session:source_to_rendered(5)
   local total = vim.api.nvim_buf_line_count(session.buf)
   expected = math.min(expected, total)
-  assert_eq(vim.api.nvim_win_get_cursor(render_win)[1], expected,
-    "render cursor should follow source to mapped line")
+  assert_eq(vim.api.nvim_win_get_cursor(render_win)[1], expected, "render cursor should follow source to mapped line")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -966,7 +1007,7 @@ end)
 -- Test 28: render CursorMoved syncs source cursor to the corresponding line
 -- ----------------------------------------------------------------------
 test("render cursor move syncs source window cursor", function()
-  local source = setup_md_buffer({ "# Heading", "", "para 1", "", "para 2" })
+  local source = setup_md_buffer { "# Heading", "", "para 1", "", "para 2" }
   local source_win = vim.api.nvim_get_current_win()
 
   local before_wins = vim.api.nvim_tabpage_list_wins(0)
@@ -984,8 +1025,11 @@ test("render cursor move syncs source window cursor", function()
 
   local expected_source = session:rendered_to_source(target_render)
   if expected_source then
-    assert_eq(vim.api.nvim_win_get_cursor(source_win)[1], expected_source,
-      "source cursor should follow render to mapped line")
+    assert_eq(
+      vim.api.nvim_win_get_cursor(source_win)[1],
+      expected_source,
+      "source cursor should follow render to mapped line"
+    )
   end
 
   vim.api.nvim_win_close(render_win, true)
@@ -996,19 +1040,18 @@ end)
 -- Test 29: cursor sync is a no-op when only one side has a window
 -- ----------------------------------------------------------------------
 test("cursor sync no-op when only source is visible", function()
-  local source = setup_md_buffer({ "# A", "", "B", "", "C" })
+  local source = setup_md_buffer { "# A", "", "B", "", "C" }
   local source_win = vim.api.nvim_get_current_win()
 
   -- Create the session via toggle then return to source so render is hidden.
   preview.toggle()
-  preview.toggle()  -- back to source
+  preview.toggle() -- back to source
 
   -- Should not error: no render window exists, sync handler returns early.
   vim.api.nvim_win_set_cursor(source_win, { 3, 0 })
   vim.cmd "doautocmd CursorMoved"
 
-  assert_eq(vim.api.nvim_win_get_cursor(source_win)[1], 3,
-    "source cursor unchanged when no render window")
+  assert_eq(vim.api.nvim_win_get_cursor(source_win)[1], 3, "source cursor unchanged when no render window")
 
   clear_win_state(source_win)
   cleanup_buffer(source)
@@ -1018,7 +1061,7 @@ end)
 -- Test 30: BufWipeout removes the scroll-sync augroup
 -- ----------------------------------------------------------------------
 test("BufWipeout removes the scroll-sync augroup", function()
-  local source = setup_md_buffer({ "# A" })
+  local source = setup_md_buffer { "# A" }
   preview.toggle()
   local augroup_name = "md_render_toggle_sync_" .. source
 
@@ -1056,7 +1099,9 @@ local function clear_sync_locks()
   for _, session in pairs(preview._toggle_sessions or {}) do
     session._syncing = false
     if session._sync_unlock_timer then
-      pcall(function() session._sync_unlock_timer:stop() end)
+      pcall(function()
+        session._sync_unlock_timer:stop()
+      end)
       session._sync_unlock_timer = nil
     end
   end
@@ -1099,8 +1144,7 @@ test("source at file top -> render at file top", function()
   local render_view = vim.api.nvim_win_call(render_win, function()
     return vim.fn.winsaveview()
   end)
-  assert_eq(render_view.topline, 1,
-    "render.topline should be 1 when source is at file top")
+  assert_eq(render_view.topline, 1, "render.topline should be 1 when source is at file top")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1126,10 +1170,9 @@ test("source at file bottom -> render at file bottom", function()
   vim.cmd "doautocmd CursorMoved"
 
   local render_botline = vim.api.nvim_win_call(render_win, function()
-    return vim.fn.line("w$")
+    return vim.fn.line "w$"
   end)
-  assert_eq(render_botline, render_lines,
-    "render.botline should equal render_lines when source is at file bottom")
+  assert_eq(render_botline, render_lines, "render.botline should equal render_lines when source is at file bottom")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1152,8 +1195,7 @@ test("render at file top -> source at file top", function()
   local source_view = vim.api.nvim_win_call(source_win, function()
     return vim.fn.winsaveview()
   end)
-  assert_eq(source_view.topline, 1,
-    "source.topline should be 1 when render is at file top")
+  assert_eq(source_view.topline, 1, "source.topline should be 1 when render is at file top")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1179,10 +1221,9 @@ test("render at file bottom -> source at file bottom", function()
   vim.cmd "doautocmd CursorMoved"
 
   local source_botline = vim.api.nvim_win_call(source_win, function()
-    return vim.fn.line("w$")
+    return vim.fn.line "w$"
   end)
-  assert_eq(source_botline, source_lines,
-    "source.botline should equal source_lines when render is at file bottom")
+  assert_eq(source_botline, source_lines, "source.botline should equal source_lines when render is at file bottom")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1231,10 +1272,9 @@ test("source at bottom -> render at bottom (with wrapped lines)", function()
   vim.cmd "doautocmd CursorMoved"
 
   local render_botline = vim.api.nvim_win_call(render_win, function()
-    return vim.fn.line("w$")
+    return vim.fn.line "w$"
   end)
-  assert_eq(render_botline, render_lines,
-    "render.botline should equal render_lines even when source has wrapped lines")
+  assert_eq(render_botline, render_lines, "render.botline should equal render_lines even when source has wrapped lines")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1259,10 +1299,9 @@ test("render at bottom -> source at bottom (with wrapped lines)", function()
   vim.cmd "doautocmd CursorMoved"
 
   local source_botline = vim.api.nvim_win_call(source_win, function()
-    return vim.fn.line("w$")
+    return vim.fn.line "w$"
   end)
-  assert_eq(source_botline, source_lines,
-    "source.botline should equal source_lines even when render has wrapped lines")
+  assert_eq(source_botline, source_lines, "source.botline should equal source_lines even when render has wrapped lines")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1282,10 +1321,9 @@ test("source at top -> render at top (with wrapped lines)", function()
   set_source_view(source_win, 1, 1)
 
   local render_topline = vim.api.nvim_win_call(render_win, function()
-    return vim.fn.line("w0")
+    return vim.fn.line "w0"
   end)
-  assert_eq(render_topline, 1,
-    "render.topline should be 1 when source snaps to file top")
+  assert_eq(render_topline, 1, "render.topline should be 1 when source snaps to file top")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1306,10 +1344,9 @@ test("render at top -> source at top (with wrapped lines)", function()
   set_view(render_win, 1, 1)
 
   local source_topline = vim.api.nvim_win_call(source_win, function()
-    return vim.fn.line("w0")
+    return vim.fn.line "w0"
   end)
-  assert_eq(source_topline, 1,
-    "source.topline should be 1 when render snaps to file top")
+  assert_eq(source_topline, 1, "source.topline should be 1 when render snaps to file top")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1326,7 +1363,9 @@ local function get_shadow_lines(buf)
   if not vim.api.nvim_buf_is_valid(buf) then return {} end
   local marks = vim.api.nvim_buf_get_extmarks(buf, SHADOW_NS, 0, -1, {})
   local lines = {}
-  for _, m in ipairs(marks) do table.insert(lines, m[2] + 1) end
+  for _, m in ipairs(marks) do
+    table.insert(lines, m[2] + 1)
+  end
   table.sort(lines)
   return lines
 end
@@ -1340,12 +1379,12 @@ local function trigger_shadow(source_buf)
 end
 
 test("split paints render shadow on initial source cursor line", function()
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "# Heading",
     "",
     "paragraph one",
     "paragraph two",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_cursor(source_win, { 3, 0 })
 
@@ -1357,22 +1396,20 @@ test("split paints render shadow on initial source cursor line", function()
   trigger_shadow(source)
 
   local render_shadow = get_shadow_lines(session.buf)
-  assert_true(#render_shadow > 0,
-    "render buf should carry shadow extmarks for source line 3")
-  assert_eq(get_shadow_lines(source), {},
-    "source buf has no shadow while it owns focus")
+  assert_true(#render_shadow > 0, "render buf should carry shadow extmarks for source line 3")
+  assert_eq(get_shadow_lines(source), {}, "source buf has no shadow while it owns focus")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
 end)
 
 test("focus on render buffer paints shadow on source side and clears render side", function()
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "# Heading",
     "",
     "paragraph one",
     "paragraph two",
-  })
+  }
   preview.split()
   local session = preview._toggle_sessions[source]
   local render_win = find_render_win(source)
@@ -1385,20 +1422,19 @@ test("focus on render buffer paints shadow on source side and clears render side
 
   local source_shadow = get_shadow_lines(source)
   assert_eq(#source_shadow, 1, "source side should hold a single-line shadow")
-  assert_eq(get_shadow_lines(session.buf), {},
-    "render side should clear its shadow once it owns focus")
+  assert_eq(get_shadow_lines(session.buf), {}, "render side should clear its shadow once it owns focus")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
 end)
 
 test("focus back to source clears source shadow and re-paints render", function()
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "# Heading",
     "",
     "paragraph one",
     "paragraph two",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   preview.split()
   local session = preview._toggle_sessions[source]
@@ -1421,7 +1457,7 @@ test("source cursor movement updates render shadow", function()
   -- Blank lines between paragraphs so each is its own block; otherwise
   -- join_paragraph_continuations collapses them and only the first
   -- source line of the paragraph appears in source_line_map.
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "# Heading",
     "",
     "paragraph one",
@@ -1429,7 +1465,7 @@ test("source cursor movement updates render shadow", function()
     "paragraph two",
     "",
     "paragraph three",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   preview.split()
   local session = preview._toggle_sessions[source]
@@ -1443,21 +1479,19 @@ test("source cursor movement updates render shadow", function()
   trigger_shadow(source)
   local second = get_shadow_lines(session.buf)
 
-  assert_true(#first > 0 and #second > 0,
-    "both positions should produce shadows")
-  assert_false(vim.deep_equal(first, second),
-    "shadow should differ between source cursor positions")
+  assert_true(#first > 0 and #second > 0, "both positions should produce shadows")
+  assert_false(vim.deep_equal(first, second), "shadow should differ between source cursor positions")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
 end)
 
 test("heading source line maps to a contiguous render shadow range", function()
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "# Heading One",
     "",
     "body line",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   preview.split()
   local session = preview._toggle_sessions[source]
@@ -1470,8 +1504,7 @@ test("heading source line maps to a contiguous render shadow range", function()
   assert_true(#shadow >= 1, "heading should yield at least one shadow line")
   if #shadow > 1 then
     for i = 2, #shadow do
-      assert_eq(shadow[i], shadow[i - 1] + 1,
-        "shadow lines should be contiguous (no gaps)")
+      assert_eq(shadow[i], shadow[i - 1] + 1, "shadow lines should be contiguous (no gaps)")
     end
   end
 
@@ -1480,11 +1513,11 @@ test("heading source line maps to a contiguous render shadow range", function()
 end)
 
 test("source cursor on the last line does not crash (sentinel handling)", function()
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "# Heading",
     "",
     "tail line",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   preview.split()
   local session = preview._toggle_sessions[source]
@@ -1500,11 +1533,11 @@ test("source cursor on the last line does not crash (sentinel handling)", functi
 end)
 
 test("closing the render split clears shadows on both sides", function()
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "# Heading",
     "",
     "body",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   preview.split()
   local session = preview._toggle_sessions[source]
@@ -1517,12 +1550,12 @@ test("closing the render split clears shadows on both sides", function()
   vim.api.nvim_set_current_win(source_win)
   vim.api.nvim_win_close(render_win, true)
   -- WinClosed handler defers via vim.schedule.
-  vim.wait(50, function() return false end)
+  vim.wait(50, function()
+    return false
+  end)
 
-  assert_eq(get_shadow_lines(source), {},
-    "source shadow cleared after split closes")
-  assert_eq(get_shadow_lines(session.buf), {},
-    "render shadow cleared after split closes")
+  assert_eq(get_shadow_lines(source), {}, "source shadow cleared after split closes")
+  assert_eq(get_shadow_lines(session.buf), {}, "render shadow cleared after split closes")
 
   cleanup_buffer(source)
 end)
@@ -1531,13 +1564,13 @@ test("source line inside a joined paragraph highlights the whole block", functio
   -- Three consecutive non-blank lines form a single paragraph in
   -- CommonMark; only the first source line appears in source_line_map,
   -- so cursor on lines 2 or 3 must fall back to the owner block (line 1).
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "first paragraph line",
     "continuation line",
     "another continuation",
     "",
     "next paragraph",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   preview.split()
   local session = preview._toggle_sessions[source]
@@ -1551,14 +1584,12 @@ test("source line inside a joined paragraph highlights the whole block", functio
   vim.api.nvim_win_set_cursor(source_win, { 2, 0 })
   trigger_shadow(source)
   local block_for_line_2 = get_shadow_lines(session.buf)
-  assert_eq(block_for_line_2, block_for_line_1,
-    "continuation line 2 should highlight the same block as line 1")
+  assert_eq(block_for_line_2, block_for_line_1, "continuation line 2 should highlight the same block as line 1")
 
   vim.api.nvim_win_set_cursor(source_win, { 3, 0 })
   trigger_shadow(source)
   local block_for_line_3 = get_shadow_lines(session.buf)
-  assert_eq(block_for_line_3, block_for_line_1,
-    "continuation line 3 should also highlight the owner block")
+  assert_eq(block_for_line_3, block_for_line_1, "continuation line 3 should also highlight the owner block")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
@@ -1571,13 +1602,13 @@ test("render shadow skips rows occupied by image placements", function()
   -- fires from CursorMoved inside the render window, so source-side
   -- cursor moves would leave the image gone. Image rows must be
   -- excluded from the shadow line set.
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "first paragraph line",
     "continuation line",
     "another continuation",
     "",
     "next paragraph",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   preview.split()
   local session = preview._toggle_sessions[source]
@@ -1586,8 +1617,7 @@ test("render shadow skips rows occupied by image placements", function()
   vim.api.nvim_win_set_cursor(source_win, { 1, 0 })
   trigger_shadow(source)
   local before = get_shadow_lines(session.buf)
-  assert_true(#before >= 1,
-    "paragraph block should produce at least one shadow row")
+  assert_true(#before >= 1, "paragraph block should produce at least one shadow row")
 
   -- Inject a fake image placement that occupies one of the rows the
   -- shadow currently covers. Use 0-indexed line + rows like real
@@ -1604,26 +1634,23 @@ test("render shadow skips rows occupied by image placements", function()
   trigger_shadow(source)
   local after = get_shadow_lines(session.buf)
   for _, l in ipairs(after) do
-    assert_false(l == target,
-      "image-occupied row " .. tostring(target) ..
-        " should be absent from the shadow line set")
+    assert_false(l == target, "image-occupied row " .. tostring(target) .. " should be absent from the shadow line set")
   end
-  assert_eq(#after, #before - 1,
-    "shadow should drop exactly the image-occupied row")
+  assert_eq(#after, #before - 1, "shadow should drop exactly the image-occupied row")
 
   vim.api.nvim_win_close(render_win, true)
   cleanup_buffer(source)
 end)
 
 test("render shadow excludes multi-row image placements entirely", function()
-  local source = setup_md_buffer({
+  local source = setup_md_buffer {
     "first paragraph line",
     "continuation line",
     "another continuation",
     "tail line",
     "",
     "next paragraph",
-  })
+  }
   local source_win = vim.api.nvim_get_current_win()
   preview.split()
   local session = preview._toggle_sessions[source]
@@ -1632,8 +1659,7 @@ test("render shadow excludes multi-row image placements entirely", function()
   vim.api.nvim_win_set_cursor(source_win, { 1, 0 })
   trigger_shadow(source)
   local before = get_shadow_lines(session.buf)
-  assert_true(#before >= 1,
-    "paragraph block should produce at least one shadow row")
+  assert_true(#before >= 1, "paragraph block should produce at least one shadow row")
 
   -- Place a 3-row image starting at the first shadow row. Even if the
   -- block is shorter than 3 render lines, the placement still claims
@@ -1650,8 +1676,10 @@ test("render shadow excludes multi-row image placements entirely", function()
   trigger_shadow(source)
   local after = get_shadow_lines(session.buf)
   for _, l in ipairs(after) do
-    assert_false(l >= start_render and l < start_render + 3,
-      "row " .. tostring(l) .. " falls inside the image span and should be excluded")
+    assert_false(
+      l >= start_render and l < start_render + 3,
+      "row " .. tostring(l) .. " falls inside the image span and should be excluded"
+    )
   end
 
   vim.api.nvim_win_close(render_win, true)
@@ -1659,6 +1687,4 @@ test("render shadow excludes multi-row image placements entirely", function()
 end)
 
 print(string.format("toggle_test: %d passed, %d failed", pass_count, fail_count))
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/tty_test.lua
+++ b/tests/tty_test.lua
@@ -48,7 +48,7 @@ pcall(ffi.cdef, "int open(const char *path, int flags); int close(int fd);")
 test("isatty returns 0 for a regular file fd", function()
   local tmpfile = os.tmpname()
   local f = io.open(tmpfile, "w")
-  f:write("test")
+  f:write "test"
   f:close()
   local fd = ffi.C.open(tmpfile, 0) -- O_RDONLY
   assert_true(fd >= 0, "open regular file should succeed")
@@ -60,7 +60,7 @@ end)
 test("ttyname returns nil for a non-tty fd", function()
   local tmpfile = os.tmpname()
   local f = io.open(tmpfile, "w")
-  f:write("test")
+  f:write "test"
   f:close()
   local fd = ffi.C.open(tmpfile, 0)
   local name = ffi.C.ttyname(fd)
@@ -75,8 +75,10 @@ test("_detect_direct returns nil in headless mode", function()
   tty.reset()
   local result = tty._detect_direct()
   -- result can be nil (headless) or a string (real terminal) — both are valid
-  assert_true(result == nil or type(result) == "string",
-    "_detect_direct should return nil or string, got: " .. type(tostring(result)))
+  assert_true(
+    result == nil or type(result) == "string",
+    "_detect_direct should return nil or string, got: " .. type(tostring(result))
+  )
 end)
 
 test("get_tty_path caches result", function()
@@ -100,15 +102,14 @@ test("_detect_socket_peer returns nil when no connected sockets", function()
   -- Just verify it doesn't crash and returns nil or a string
   tty.reset()
   local result = tty._detect_socket_peer()
-  assert_true(result == nil or type(result) == "string",
-    "_detect_socket_peer should return nil or string")
+  assert_true(result == nil or type(result) == "string", "_detect_socket_peer should return nil or string")
 end)
 
 test("_get_socket_peer_pid returns nil for non-socket fd", function()
   pcall(ffi.cdef, "int open(const char *path, int flags); int close(int fd);")
   local tmpfile = os.tmpname()
   local f = io.open(tmpfile, "w")
-  f:write("test")
+  f:write "test"
   f:close()
   local fd = ffi.C.open(tmpfile, 0)
   local peer = tty._get_socket_peer_pid(fd)
@@ -123,12 +124,11 @@ end)
 
 if ffi.os == "OSX" then
   test("macOS: proc_bsdinfo struct size is 136 bytes", function()
-    assert_eq(ffi.sizeof("struct md_proc_bsdinfo"), 136,
-      "proc_bsdinfo should be 136 bytes (validates struct layout)")
+    assert_eq(ffi.sizeof "struct md_proc_bsdinfo", 136, "proc_bsdinfo should be 136 bytes (validates struct layout)")
   end)
 
   test("macOS: proc_pidinfo succeeds for own pid", function()
-    local info = ffi.new("struct md_proc_bsdinfo")
+    local info = ffi.new "struct md_proc_bsdinfo"
     local pid = vim.fn.getpid()
     local size = ffi.C.proc_pidinfo(pid, 3, 0, info, ffi.sizeof(info))
     assert_true(size > 0, "proc_pidinfo should return positive size for own pid")
@@ -137,8 +137,10 @@ if ffi.os == "OSX" then
 
   test("macOS: _get_pid_tty_darwin returns nil or string for own pid", function()
     local result = tty._get_pid_tty_darwin(vim.fn.getpid())
-    assert_true(result == nil or type(result) == "string",
-      "_get_pid_tty_darwin should return nil (headless) or string (terminal)")
+    assert_true(
+      result == nil or type(result) == "string",
+      "_get_pid_tty_darwin should return nil (headless) or string (terminal)"
+    )
   end)
 
   test("macOS: devname returns string for valid dev", function()
@@ -167,13 +169,11 @@ if ffi.os == "Linux" then
   test("Linux: _get_pid_tty_linux parses stat correctly", function()
     local result = tty._get_pid_tty_linux(vim.fn.getpid())
     -- In headless mode, tty_nr is likely 0, so result should be nil
-    assert_true(result == nil or type(result) == "string",
-      "_get_pid_tty_linux should return nil (no tty) or string")
+    assert_true(result == nil or type(result) == "string", "_get_pid_tty_linux should return nil (no tty) or string")
   end)
 
   test("Linux: ucred struct size is 12 bytes", function()
-    assert_eq(ffi.sizeof("struct md_ucred"), 12,
-      "ucred should be 12 bytes (pid + uid + gid)")
+    assert_eq(ffi.sizeof "struct md_ucred", 12, "ucred should be 12 bytes (pid + uid + gid)")
   end)
 end
 
@@ -182,6 +182,4 @@ end
 -- ============================================================================
 
 print(string.format("\n%d passed, %d failed", pass_count, fail_count))
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/url_hover_test.lua
+++ b/tests/url_hover_test.lua
@@ -60,7 +60,7 @@ end)
 
 local function make_buf_with_url(line_text, url, start_col, end_col)
   local buf = vim.api.nvim_create_buf(false, true)
-  local ns = vim.api.nvim_create_namespace("url_hover_test")
+  local ns = vim.api.nvim_create_namespace "url_hover_test"
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, { line_text })
   vim.api.nvim_buf_set_extmark(buf, ns, 0, start_col, {
     end_col = end_col,
@@ -97,7 +97,7 @@ end)
 
 test("url_at_mouse: returns nil when extmark has no URL", function()
   local buf = vim.api.nvim_create_buf(false, true)
-  local ns = vim.api.nvim_create_namespace("url_hover_test2")
+  local ns = vim.api.nvim_create_namespace "url_hover_test2"
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "Some text" })
   vim.api.nvim_buf_set_extmark(buf, ns, 0, 0, { end_col = 4, hl_group = "Comment" })
   assert_eq(internal.url_at_mouse({ winid = 1, line = 1, column = 2 }, buf, ns), nil, "non-URL extmark ignored")
@@ -159,9 +159,14 @@ end)
 test("attach: registers window for hover", function()
   local buf = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "x" })
-  local ns = vim.api.nvim_create_namespace("attach_test")
+  local ns = vim.api.nvim_create_namespace "attach_test"
   local win = vim.api.nvim_open_win(buf, false, {
-    relative = "editor", width = 5, height = 1, row = 0, col = 0, style = "minimal",
+    relative = "editor",
+    width = 5,
+    height = 1,
+    row = 0,
+    col = 0,
+    style = "minimal",
   })
   UrlHover.attach(buf, ns, win)
   assert_eq(internal.registered[win] ~= nil, true, "window registered")
@@ -170,12 +175,12 @@ test("attach: registers window for hover", function()
 
   vim.api.nvim_win_close(win, true)
   -- WinClosed autocmd should clear registration
-  vim.wait(50, function() return internal.registered[win] == nil end)
+  vim.wait(50, function()
+    return internal.registered[win] == nil
+  end)
   assert_eq(internal.registered[win], nil, "WinClosed cleared registration")
 end)
 
 -- Summary
 print(string.format("\n%d passed, %d failed", pass_count, fail_count))
-if fail_count > 0 then
-  os.exit(1)
-end
+if fail_count > 0 then os.exit(1) end

--- a/tests/visual_test_init.lua
+++ b/tests/visual_test_init.lua
@@ -7,7 +7,7 @@ local plugin_root = vim.fn.getcwd()
 vim.opt.runtimepath:prepend(plugin_root)
 
 -- Load the plugin
-vim.cmd("runtime plugin/md-render.lua")
+vim.cmd "runtime plugin/md-render.lua"
 
 -- Open the test markdown file
 vim.cmd("edit " .. plugin_root .. "/tests/fixtures/visual_test.md")
@@ -27,7 +27,7 @@ vim.defer_fn(function()
   vim.defer_fn(function()
     local f = io.open(signal, "w")
     if f then
-      f:write("ready\n")
+      f:write "ready\n"
       f:close()
     end
   end, 5000)


### PR DESCRIPTION
StyLua の設定ファイルを導入し、リポジトリ全体を一度きりで整形しました。以降の差分はフォーマット起因のノイズが入らなくなります。

挙動の変更はありません(整形のみ)。

## `.stylua.toml`

```toml
column_width = 120
line_endings = "Unix"
syntax = "LuaJIT"
indent_type = "Spaces"
indent_width = 2
quote_style = "AutoPreferDouble"
no_call_parentheses = true
collapse_simple_statement = "ConditionalOnly"
```

- `collapse_simple_statement = "ConditionalOnly"` — `if x then break end` のような 1 行ガード節を維持(既存の手書きスタイルに合わせる)。関数本体は展開する。
- `syntax = "LuaJIT"` — Neovim は LuaJIT 上で動くため明示。これが無いと `goto`/ラベル構文 (`::continue::` / `::finalize::`) が Luau のラベル構文と衝突して parse できない。

## 確認

- `stylua --check lua/ tests/ plugin/` がクリーン(冪等)。
- `make test` 全パス(回帰なし)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)