### PR TITLE
feat(preview): click to expand truncated YAML frontmatter values

### DIFF
--- a/lua/md-render/preview.lua
+++ b/lua/md-render/preview.lua
@@ -2,6 +2,7 @@ local FloatWin = require "md-render.float_win"
 local TabWin = require "md-render.tab_win"
 local cb = require "md-render.content_builder"
 local display_utils = require "md-render.display_utils"
+local wrap = require "md-render.wrap"
 local ContentBuilder = cb.ContentBuilder
 
 local float_win = FloatWin.new "md_render_preview_float"
@@ -77,6 +78,7 @@ end
 MdPreview.build_content = function(lines, opts)
   opts = opts or {}
   local max_width = opts.max_width or DEFAULT_MAX_WIDTH
+  local expand_state = opts.expand_state or {}
 
   local b = ContentBuilder.new()
 
@@ -98,25 +100,66 @@ MdPreview.build_content = function(lines, opts)
         b:add_line("  Properties", {
           { col = 2, end_col = 2 + #"Properties", hl = "Title" },
         })
+        -- Unique block id per overflowing frontmatter entry. Negative so it
+        -- can never collide with table expand ids, which are positive source
+        -- line numbers. Stable across rebuilds because entries parse
+        -- deterministically, so expand_state persists per entry.
+        local fm_block_counter = 0
         for _, entry in ipairs(entries) do
           local label = "  " .. entry.key
+          -- Byte/display column where the value starts, after "<label>: ".
+          -- label is ASCII (key matches [%w_%-]+), so bytes == display cols.
+          local value_col = #label + 2
           local full_line = label .. ": " .. entry.value
           local display_width = vim.api.nvim_strwidth(full_line)
           if display_width > max_width then
-            local target = max_width - vim.api.nvim_strwidth "…"
-            local current_width = 0
-            local byte_pos = 0
-            for char in full_line:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
-              local char_width = vim.api.nvim_strwidth(char)
-              if current_width + char_width > target then break end
-              current_width = current_width + char_width
-              byte_pos = byte_pos + #char
+            fm_block_counter = fm_block_counter + 1
+            local block_id = -fm_block_counter
+            local expanded = expand_state[block_id] or false
+            local start_line = #b.lines
+            if expanded then
+              -- Wrap the value across lines, aligning continuation lines
+              -- under the value's start column (like a table cell expand).
+              local value_width = math.max(1, max_width - value_col)
+              local wrapped = wrap.wrap_words(entry.value, value_width)
+              local cont_indent = string.rep(" ", value_col)
+              for idx, wline in ipairs(wrapped) do
+                if idx == 1 then
+                  local line = label .. ": " .. wline
+                  b:add_line(line, {
+                    { col = 0, end_col = #label, hl = "Comment" },
+                    { col = value_col, end_col = #line, hl = "String" },
+                  })
+                else
+                  local line = cont_indent .. wline
+                  b:add_line(line, {
+                    { col = value_col, end_col = #line, hl = "String" },
+                  })
+                end
+              end
+            else
+              local target = max_width - vim.api.nvim_strwidth "…"
+              local current_width = 0
+              local byte_pos = 0
+              for char in full_line:gmatch "[%z\1-\127\194-\253][\128-\191]*" do
+                local char_width = vim.api.nvim_strwidth(char)
+                if current_width + char_width > target then break end
+                current_width = current_width + char_width
+                byte_pos = byte_pos + #char
+              end
+              local truncated = full_line:sub(1, byte_pos) .. "…"
+              b:add_line(truncated, {
+                { col = 0, end_col = #label, hl = "Comment" },
+                { col = value_col, end_col = byte_pos, hl = "String" },
+                { col = byte_pos, end_col = #truncated, hl = "Underlined" },
+              })
             end
-            local truncated = full_line:sub(1, byte_pos) .. "…"
-            b:add_line(truncated, {
-              { col = 0, end_col = #label, hl = "Comment" },
-              { col = #label + 2, end_col = byte_pos, hl = "String" },
-              { col = byte_pos, end_col = #truncated, hl = "Underlined" },
+            -- Register the region so clicking / za / <CR> toggles expansion.
+            table.insert(b.expandable_regions, {
+              start_line = start_line,
+              end_line = #b.lines - 1,
+              block_id = block_id,
+              expanded = expanded,
             })
           else
             b:add_labeled(label, entry.value, "String")

--- a/tests/frontmatter_test.lua
+++ b/tests/frontmatter_test.lua
@@ -1,0 +1,140 @@
+-- Test YAML frontmatter rendering: truncation of overflowing values and
+-- click-to-expand (mirrors table-cell expand behavior).
+-- Run: nvim --headless -u NONE --noplugin -l tests/frontmatter_test.lua
+
+package.path = vim.fn.getcwd() .. "/lua/?.lua;" .. vim.fn.getcwd() .. "/lua/?/init.lua;" .. package.path
+
+local preview = require "md-render.preview"
+
+local pass_count = 0
+local fail_count = 0
+
+local function assert_eq(actual, expected, msg)
+  if vim.deep_equal(actual, expected) then
+    pass_count = pass_count + 1
+  else
+    fail_count = fail_count + 1
+    print("FAIL: " .. msg)
+    print("  expected: " .. vim.inspect(expected))
+    print("  actual:   " .. vim.inspect(actual))
+  end
+end
+
+local function assert_true(val, msg)
+  if val then
+    pass_count = pass_count + 1
+  else
+    fail_count = fail_count + 1
+    print("FAIL: " .. msg)
+  end
+end
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if not ok then
+    fail_count = fail_count + 1
+    print("ERROR: " .. name .. ": " .. tostring(err))
+  end
+end
+
+-- A value long enough to overflow a narrow render width.
+local LONG_VALUE = "あいうえおかきくけこさしすせそたちつてと"
+local MAX_WIDTH = 20
+
+-- ----------------------------------------------------------------------
+-- Test 1: an overflowing frontmatter value is truncated with "…" and
+-- registers an expandable region with a negative (frontmatter) block id.
+-- ----------------------------------------------------------------------
+test("overflowing frontmatter value truncates and registers a region", function()
+  local lines = { "---", "hoge: " .. LONG_VALUE, "---", "", "body" }
+  local content = preview.build_content(lines, { max_width = MAX_WIDTH })
+
+  assert_eq(#content.expandable_regions, 1, "one expandable region for the overflowing entry")
+  local region = content.expandable_regions[1]
+  assert_true(region.block_id < 0, "frontmatter block id is negative (got " .. region.block_id .. ")")
+  assert_eq(region.expanded, false, "region starts collapsed")
+  assert_eq(region.start_line, region.end_line, "collapsed entry occupies a single line")
+
+  local line = content.lines[region.start_line + 1]
+  assert_true(line:sub(1, #"  hoge: ") == "  hoge: ", "line keeps the '  hoge: ' label prefix")
+  assert_true(line:match "…$" ~= nil, "collapsed line ends with the … ellipsis")
+  assert_true(vim.api.nvim_strwidth(line) <= MAX_WIDTH, "collapsed line fits within max_width")
+end)
+
+-- ----------------------------------------------------------------------
+-- Test 2: expanding the entry wraps the value across lines, aligned to
+-- the value column, and keeps the region clickable (still registered).
+-- ----------------------------------------------------------------------
+test("expanded frontmatter value wraps aligned to the value column", function()
+  local lines = { "---", "hoge: " .. LONG_VALUE, "---", "", "body" }
+
+  -- First pass: discover the block id.
+  local collapsed = preview.build_content(lines, { max_width = MAX_WIDTH })
+  local block_id = collapsed.expandable_regions[1].block_id
+
+  -- Second pass with that entry expanded.
+  local content = preview.build_content(lines, {
+    max_width = MAX_WIDTH,
+    expand_state = { [block_id] = true },
+  })
+
+  local region = content.expandable_regions[1]
+  assert_eq(region.expanded, true, "region reports expanded")
+  assert_true(region.end_line > region.start_line, "expanded entry spans multiple lines")
+
+  local first = content.lines[region.start_line + 1]
+  assert_true(first:sub(1, #"  hoge: ") == "  hoge: ", "first line keeps the label prefix")
+  assert_true(first:match "…$" == nil, "expanded first line has no ellipsis")
+
+  -- Continuation lines are indented to align under the value (col of "hoge: ").
+  local value_col = #"  hoge" + 2 -- "  hoge" + ": "
+  local expected_indent = string.rep(" ", value_col)
+  for l = region.start_line + 1, region.end_line do
+    local line = content.lines[l + 1]
+    assert_true(vim.api.nvim_strwidth(line) <= MAX_WIDTH, "wrapped line " .. l .. " fits within max_width")
+  end
+  local second = content.lines[region.start_line + 2]
+  assert_true(second:sub(1, #expected_indent) == expected_indent, "continuation line is indented to the value column")
+  assert_true(second:sub(#expected_indent + 1, #expected_indent + 1) ~= " ", "continuation content follows the indent")
+
+  -- The concatenation of value fragments reconstructs the original value.
+  local parts = {}
+  table.insert(parts, first:sub(value_col + 1))
+  for l = region.start_line + 1, region.end_line do
+    table.insert(parts, (content.lines[l + 1]):sub(value_col + 1))
+  end
+  local joined = table.concat(parts)
+  assert_eq(joined, LONG_VALUE, "expanded fragments reconstruct the original value")
+end)
+
+-- ----------------------------------------------------------------------
+-- Test 3: a short value that fits gets no region and no ellipsis.
+-- ----------------------------------------------------------------------
+test("short frontmatter value is left untouched", function()
+  local lines = { "---", "k: v", "---", "", "body" }
+  local content = preview.build_content(lines, { max_width = MAX_WIDTH })
+  assert_eq(#content.expandable_regions, 0, "no region for a value that fits")
+end)
+
+-- ----------------------------------------------------------------------
+-- Test 4: multiple overflowing entries get distinct block ids.
+-- ----------------------------------------------------------------------
+test("multiple overflowing entries get distinct block ids", function()
+  local lines = {
+    "---",
+    "a: " .. LONG_VALUE,
+    "b: " .. LONG_VALUE,
+    "---",
+    "",
+    "body",
+  }
+  local content = preview.build_content(lines, { max_width = MAX_WIDTH })
+  assert_eq(#content.expandable_regions, 2, "two regions for two overflowing entries")
+  local id1 = content.expandable_regions[1].block_id
+  local id2 = content.expandable_regions[2].block_id
+  assert_true(id1 ~= id2, "block ids are distinct (" .. id1 .. " vs " .. id2 .. ")")
+  assert_true(id1 < 0 and id2 < 0, "both block ids are negative")
+end)
+
+print(string.format("\n%d passed, %d failed", pass_count, fail_count))
+if fail_count > 0 then vim.cmd "cquit 1" end


### PR DESCRIPTION
## 概要

Obsidian ノート等のプレビューで、YAML フロントマターの横幅を越えた値は `…` で省略表示されますが、テーブルのセルと違ってクリックしても展開できませんでした。テーブルと同じ操作で展開できるようにします。

Before:

\`\`\`yaml
hoge: あいうえおかきく…
\`\`\`

クリック / \`za\` / \`<CR>\` で After:

\`\`\`yaml
hoge: あいうえおかきく
      けこ
\`\`\`

## 実装

- 折り返し省略された各エントリを \`expandable_regions\` として登録し、既存の \`expand_state\` / \`block_id\` 機構と共通のクリック / \`za\` / \`<CR>\` ハンドラでトグルできるようにした (テーブルのセル展開と同じ経路)。
- 展開時は値を \`wrap_words\` (CJK・禁則処理対応) で折り返し、継続行を値の開始桁 (\`key: \` の直後) にインデント揃え。
- フロントマターの \`block_id\` は負数を採番し、テーブルの展開 ID (正のソース行番号) と衝突しないようにした。パースは決定的なので rebuild をまたいでも展開状態は各エントリに保持される。
- 値内に URL がある場合はクリックで展開ではなくリンクを開く、という既存の優先順位もそのまま。

## テスト

- 新規 \`tests/frontmatter_test.lua\` (21 アサーション): 省略表示・展開時の折り返しとインデント揃え・元の値の復元・複数エントリの ID 一意性を確認。
- 既存スイートに回帰なし (toggle 149 / key_toggle 18 ほか全て green)。stylua / luacheck も pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)