### PR TITLE
Fix for mermaid rendering when the diagram is initially out of view

### DIFF
--- a/lua/md-render/display_utils.lua
+++ b/lua/md-render/display_utils.lua
@@ -986,7 +986,14 @@ function M.setup_images(win, content, ns, opts)
       return
     end
     local placement = state.placements[idx]
-    if placement_near_viewport(placement) then
+    -- Async-render placements (Mermaid diagrams, remote URL images) have no
+    -- `path` yet, so the WinScrolled-driven retry in place_images (which only
+    -- re-processes placements that already have a `.path`) can never pick them
+    -- up later. Skipping them here based on viewport would strand them on the
+    -- placeholder forever, even after the user scrolls to them. Kick off their
+    -- render/download regardless of position; only truly static images (which
+    -- retry correctly on scroll) get the lazy-viewport optimization.
+    if placement.mermaid_source or placement.src_url or placement_near_viewport(placement) then
       image.begin_batch()
       local ok, err = pcall(process_placement, placement)
       image.flush_batch()


### PR DESCRIPTION
Mermaid diagrams and remote URL images render asynchronously — their placement has no .path until the render/download completes. process_one skips any placement not near the viewport, and the WinScrolled retry in place_images only re-processes placements that already have a .path. So an async-render placement below the initial viewport is never processed (skipped at setup, ignored by the scroll retry) and stays stuck on the "Rendering mermaid diagram…" placeholder forever — even after scrolling onto it. Static images with a near-top block render fine, which masks the bug

Repro: any markdown where the ```mermaid block sits below the fold; e.g. :MdRender demo inside the small terminal window

Fix: process mermaid_source/src_url placements regardless of viewport (matching what update_images already does); static local images keep the lazy-viewport optimization since they retry correctly on scroll.