### PR TITLE
Presenter mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ vim.keymap.set("n", "<leader>md", "<Plug>(md-render-demo)",        { desc = "Mar
 | `<Plug>(md-render-toggle)` | Toggle the current window between source and render mode in place |
 | `<Plug>(md-render-auto)` | **[experimental]** Toggle auto mode (render outside Insert) for the current buffer |
 | `<Plug>(md-render-split)` | Open a split showing source and rendered Markdown |
+| `<Plug>(md-render-present)` | Enter the full-screen slideshow presenter for the current buffer |
 | `<Plug>(md-render-demo)` | Show a demo window with all supported Markdown notations |
 
 ### In-preview keys
@@ -154,6 +155,43 @@ Inside a rendered preview (floating, tab, or in-place toggle), these buffer-loca
 | `<CR>` | Toggle the fold / expandable region under the cursor (no-op elsewhere) |
 | `<LeftMouse>` | Toggle folds, expand regions, and open links by clicking |
 | `q` / `<Esc>` / `<C-c>` | Close the window (floating / tab mode only) |
+
+## Presenter mode
+
+`:MdRender present` turns the current Markdown buffer into a full-screen
+slideshow. `---` (a thematic break) separates slides; each slide fills the
+screen. Mermaid diagrams render inline as images.
+
+### In-presenter keys
+
+| Key | Action |
+|---|---|
+| `n` / `→` / `<Space>` / `<PageDown>` | Next slide |
+| `p` / `←` / `<PageUp>` | Previous slide |
+| `gg` / `G` | First / last slide |
+| `L` | Cycle the layout of the diagram on the current slide (fit → left → right → full). On a slide with multiple diagrams, the first one is affected. |
+| `<` / `>` | Narrow / widen the split (in `left`/`right`), by 5% (20–80%) |
+| `q` / `<Esc>` / `<C-c>` | Exit the presenter (restores your buffer) |
+
+### Slide metadata (hidden comments)
+
+Presenter metadata rides in link-label comments (`[//]: # (...)`) that render as
+nothing in any Markdown viewer:
+
+```markdown
+[//]: # (diagram: left:40)
+```​`​`​`mermaid
+flowchart LR
+  A --> B
+```​`​`​`
+Explanatory text flows in the right 60% of the slide.
+```
+
+Diagram layouts: `full` (the diagram fills the slide; any other text on the
+slide renders above it), `fit` (inline, coexists with text),
+`left[:N]` / `right[:N]` (diagram fills N% of that side; text takes the rest).
+When you change a layout with `L` / `<` / `>`, the comment is written back into
+the file so it sticks.
 
 ## Commands
 
@@ -168,6 +206,7 @@ The plugin exposes a single `:MdRender` command with subcommands:
 | `:MdRender split` | Open a split showing source and rendered Markdown (honours `:vert`, `:tab`, `:topleft`, `:botright`) |
 | `:MdRender auto [on\|off\|toggle]` | **[experimental]** Auto-toggle source/render based on Insert mode (per buffer) |
 | `:MdRender pager` | Pager mode — full-screen, no chrome, `q` to quit Neovim |
+| `:MdRender present` | Full-screen slideshow presenter — `---` splits slides, `L`/`<`/`>` adjust diagram layout |
 | `:MdRender demo` | Show a demo window with all supported Markdown notations |
 
 Tab completion lists the subcommands for the first arg, and `on` / `off` / `toggle` after `auto`.

--- a/doc/md-render.txt
+++ b/doc/md-render.txt
@@ -10,6 +10,7 @@ Requirements						|md-render-requirements|
 Installation						|md-render-installation|
 Mappings						    |md-render-mappings|
 Commands						    |md-render-commands|
+Presenter mode						  |md-render-presenter|
 Telescope Integration					   |md-render-telescope|
 Snacks.nvim Integration					      |md-render-snacks|
 Usage							       |md-render-usage|
@@ -131,6 +132,11 @@ Map them yourself: >lua
 <Plug>(md-render-split) ~
 	Open a split window showing the source and rendered views of the
 	current Markdown buffer.  See |:MdRender-split|.
+
+						      *<Plug>(md-render-present)*
+<Plug>(md-render-present) ~
+	Enter the full-screen slideshow presenter for the current buffer.
+	See |:MdRender-present|.
 
 							*<Plug>(md-render-demo)*
 <Plug>(md-render-demo) ~
@@ -334,6 +340,10 @@ still registered as deprecated aliases — see |md-render-deprecated-commands|.
 	  mdless README.md
 <
 
+						    *:MdRender-present*
+:MdRender present ~
+	Full-screen slideshow presenter.  See |md-render-presenter|.
+
 							      *:MdRender-demo*
 :MdRender demo ~
 	Show a demo window with all supported Markdown notations.
@@ -475,6 +485,72 @@ The preview function handles three kinds of files:
 
 For grep-based pickers the preview automatically scrolls to the matched
 source line.
+
+==============================================================================
+PRESENTER MODE						  *md-render-presenter*
+
+The presenter mode turns a Markdown buffer into a full-screen slideshow.
+`---` (a thematic break on its own line) separates slides; each slide fills
+the screen.  Mermaid diagrams render inline as images.
+
+ENTRY POINT ~
+
+The entry point is |:MdRender-present|, also accessible via
+|<Plug>(md-render-present)|.
+
+KEYS IN PRESENTER MODE ~
+
+The following keys are available inside the presenter:
+
+  `n` / `→` / `<Space>` / `<PageDown>`
+		Next slide
+
+  `p` / `←` / `<PageUp>`
+		Previous slide
+
+  `gg` / `G`
+		First / last slide
+
+  `L`	Cycle the layout of the diagram on the current slide (fit → left →
+	right → full).  On a slide with multiple diagrams, the first one is
+	affected.  The layout changes persist in the file via a hidden
+	link-label comment (see |md-render-presenter-metadata|).
+
+  `<` / `>`
+		Narrow / widen the split in `left` or `right` layout mode, by 5%
+		per keystroke.  Clamped to 20–80% to keep both the diagram and
+		text readable.  The width persists via the hidden comment.
+
+  `q` / `<Esc>` / `<C-c>`
+		Exit the presenter and restore the source buffer.
+
+SLIDE METADATA (HIDDEN COMMENTS)		*md-render-presenter-metadata*
+
+Slide metadata lives in link-label comments (in Markdown syntax,
+`[//]: # (...)`) that render as nothing in any Markdown viewer:
+
+```
+[//]: # (diagram: left:40)
+```​`​`​`mermaid
+flowchart LR
+  A --> B
+```​`​`​`
+```
+
+The comment `[//]: # (diagram: <layout>)` appears on the line *above* a
+mermaid fence and specifies that diagram's layout.
+
+Diagram layout formats: ~
+
+  `full`        The diagram fills the slide; any other text on the slide
+                renders above it
+  `fit`         Inline, coexists with text on the same slide
+  `left[:N]`    Diagram fills the left N% (default 50); text takes the right
+  `right[:N]`   Diagram fills the right N% (default 50); text takes the left
+
+When you change a layout with `L`, `<`, or `>`, the comment is automatically
+written back into the buffer.  This persists your choices across presenter
+exits and re-entries.
 
 ==============================================================================
 USAGE							       *md-render-usage*

--- a/lua/md-render/command.lua
+++ b/lua/md-render/command.lua
@@ -3,7 +3,7 @@
 
 local M = {}
 
-local SUBCOMMANDS = { "float", "tab", "pager", "toggle", "split", "auto", "demo" }
+local SUBCOMMANDS = { "float", "tab", "pager", "toggle", "split", "auto", "demo", "present" }
 local AUTO_ARGS = { "on", "off", "toggle" }
 
 local function preview()
@@ -29,6 +29,8 @@ function M.dispatch(args)
     p.split { mods = args.smods }
   elseif sub == "demo" then
     p.show_demo()
+  elseif sub == "present" then
+    p.show_present()
   elseif sub == "auto" then
     local a = (fargs[2] or "toggle"):lower()
     if a == "on" then

--- a/lua/md-render/display_utils.lua
+++ b/lua/md-render/display_utils.lua
@@ -986,7 +986,14 @@ function M.setup_images(win, content, ns, opts)
       return
     end
     local placement = state.placements[idx]
-    if placement_near_viewport(placement) then
+    -- Async-render placements (Mermaid diagrams, remote URL images) have no
+    -- `path` yet, so the WinScrolled-driven retry in place_images (which only
+    -- re-processes placements that already have a `.path`) can never pick them
+    -- up later. Skipping them here based on viewport would strand them on the
+    -- placeholder forever, even after the user scrolls to them. Kick off their
+    -- render/download regardless of position; only truly static images (which
+    -- retry correctly on scroll) get the lazy-viewport optimization.
+    if placement.mermaid_source or placement.src_url or placement_near_viewport(placement) then
       image.begin_batch()
       local ok, err = pcall(process_placement, placement)
       image.flush_batch()

--- a/lua/md-render/presenter.lua
+++ b/lua/md-render/presenter.lua
@@ -1,0 +1,546 @@
+--- Presenter mode: slide segmentation, directive parsing, layout persistence,
+--- slide rendering, and the full-screen slideshow orchestration.
+local PL = require "md-render.presenter_layout"
+
+local M = {}
+
+--- Thematic-break test (matches content_builder's rule): >=3 of -, *, or _.
+---@param line string
+---@return boolean
+local function is_thematic_break(line)
+  local stripped = line:gsub("%s", "")
+  if #stripped < 3 then return false end
+  local ch = stripped:sub(1, 1)
+  if ch ~= "-" and ch ~= "*" and ch ~= "_" then return false end
+  return stripped == string.rep(ch, #stripped)
+end
+
+--- Is this line a `[//]: # (...)` hidden link-label comment? Returns inner text.
+---@param line string
+---@return string|nil inner
+local function comment_inner(line)
+  return line:match "^%s*%[//%]:%s*#%s*%((.-)%)%s*$"
+end
+
+M._is_thematic_break = is_thematic_break
+M._comment_inner = comment_inner
+
+--- Split lines into slides at top-level thematic breaks. Breaks inside fenced
+--- code blocks and inside `[//]: #` comments do not split.
+---@param lines string[]
+---@return {start: integer, stop: integer, lines: string[]}[]
+function M.segment(lines)
+  local slides = {}
+  local in_fence = false
+  local fence_marker = nil
+  local cur = {}
+  local cur_start = 1
+
+  local function flush(stop_row)
+    local all_blank = true
+    for _, l in ipairs(cur) do
+      if l:gsub("%s", "") ~= "" then
+        all_blank = false
+        break
+      end
+    end
+    if not all_blank then
+      table.insert(slides, { start = cur_start, stop = stop_row, lines = cur })
+    end
+  end
+
+  for i, line in ipairs(lines) do
+    local trimmed = line:gsub("^%s+", "")
+    local marker = trimmed:match "^(```+)" or trimmed:match "^(~~~+)"
+    if in_fence then
+      table.insert(cur, line)
+      if marker and fence_marker and marker:sub(1, #fence_marker) == fence_marker then
+        in_fence = false
+        fence_marker = nil
+      end
+    elseif marker then
+      fence_marker = marker
+      in_fence = true
+      table.insert(cur, line)
+    elseif is_thematic_break(line) and not comment_inner(line) then
+      flush(i - 1)
+      cur = {}
+      cur_start = i + 1
+    else
+      table.insert(cur, line)
+    end
+  end
+  flush(#lines)
+  return slides
+end
+
+--- Discover mermaid diagrams in a slide, with absolute source rows and any
+--- explicitly-declared layout from a directive directly above the fence.
+---@param slide {start: integer, stop: integer, lines: string[]}
+---@return {open_row, close_row, directive_row, source, layout}[]
+function M.find_diagrams(slide)
+  local diagrams = {}
+  local lines = slide.lines
+  local i = 1
+  while i <= #lines do
+    local lang = lines[i]:match "^%s*```+%s*(%w+)" or lines[i]:match "^%s*~~~+%s*(%w+)"
+    if lang and lang:lower() == "mermaid" then
+      local open_row = slide.start + i - 1
+      local open_marker = lines[i]:match "^%s*(```+)" or lines[i]:match "^%s*(~~~+)"
+      local fence_char = open_marker:sub(1, 1)
+      local body = {}
+      local j = i + 1
+      while j <= #lines do
+        local run = lines[j]:match("^%s*(" .. fence_char .. "+)%s*$")
+        if run and #run >= #open_marker then break end
+        table.insert(body, lines[j])
+        j = j + 1
+      end
+      local close_row = slide.start + j - 1
+      -- Layout directive on the line directly above the opening fence.
+      local directive_row, layout = nil, nil
+      if i > 1 then
+        local inner = comment_inner(lines[i - 1])
+        if inner then
+          local scope, value = inner:match "^%s*(%w+)%s*:%s*(.-)%s*$"
+          if scope and scope:lower() == "diagram" then
+            layout = PL.parse_layout(value)
+            if layout then directive_row = slide.start + i - 2 end
+          end
+        end
+      end
+      table.insert(diagrams, {
+        open_row = open_row,
+        close_row = close_row,
+        directive_row = directive_row,
+        source = table.concat(body, "\n"),
+        layout = layout,
+      })
+      i = j + 1
+    else
+      i = i + 1
+    end
+  end
+  return diagrams
+end
+
+--- Parse the first `[//]: # (deck: k=v ...)` comment in the document.
+---@param lines string[]
+---@return table<string,string>
+function M.parse_deck_options(lines)
+  for _, line in ipairs(lines) do
+    local inner = comment_inner(line)
+    if inner then
+      local scope, value = inner:match "^%s*(%w+)%s*:%s*(.-)%s*$"
+      if scope and scope:lower() == "deck" then
+        local opts = {}
+        for k, v in value:gmatch "([%w%-_]+)=([^%s]+)" do
+          opts[k] = v
+        end
+        return opts
+      end
+    end
+  end
+  return {}
+end
+
+--- Is a slide's only meaningful content a single mermaid diagram?
+---@param slide {start, stop, lines}
+---@return {kind: string}
+function M.default_layout(slide)
+  local diagrams = M.find_diagrams(slide)
+  if #diagrams ~= 1 then return { kind = "fit" } end
+  local d = diagrams[1]
+  -- Any non-blank line outside the fence (and not a comment) counts as text.
+  for idx, line in ipairs(slide.lines) do
+    local abs = slide.start + idx - 1
+    local inside = abs > d.open_row and abs < d.close_row
+    local is_fence = abs == d.open_row or abs == d.close_row
+    local is_directive = abs == d.directive_row
+    if not inside and not is_fence and not is_directive then
+      if line:gsub("%s", "") ~= "" and not comment_inner(line) then return { kind = "fit" } end
+    end
+  end
+  return { kind = "full" }
+end
+
+--- The layout to use for a diagram: explicit directive, else slide default.
+---@param slide {start, stop, lines}
+---@param diagram {layout: {kind,pct?}?}
+---@return {kind: string, pct: integer?}
+function M.effective_layout(slide, diagram)
+  return diagram.layout or M.default_layout(slide)
+end
+
+--- Persist a diagram's layout as a `[//]: # (diagram: ...)` comment above its
+--- opening fence. Replaces an existing directive line, else inserts one.
+---@param bufnr integer
+---@param diagram {open_row: integer, directive_row: integer?}
+---@param layout {kind: string, pct: integer?}
+---@return integer|nil new_open_row  nil if buffer is not modifiable
+function M.write_diagram_layout(bufnr, diagram, layout)
+  if not vim.bo[bufnr].modifiable then return nil end
+  local comment = "[//]: # (diagram: " .. PL.serialize_layout(layout) .. ")"
+  if diagram.directive_row then
+    local row0 = diagram.directive_row - 1
+    vim.api.nvim_buf_set_lines(bufnr, row0, row0 + 1, false, { comment })
+    return diagram.open_row
+  end
+  local insert_at = diagram.open_row - 1
+  vim.api.nvim_buf_set_lines(bufnr, insert_at, insert_at, false, { comment })
+  return diagram.open_row + 1
+end
+
+--- Diagram whose opening fence is nearest the cursor source row.
+---@param diagrams {open_row: integer}[]
+---@param cursor_src_row integer
+---@return table|nil
+function M.nearest_diagram(diagrams, cursor_src_row)
+  local best, best_dist = nil, math.huge
+  for _, d in ipairs(diagrams) do
+    local dist = math.abs(d.open_row - cursor_src_row)
+    if dist < best_dist then
+      best, best_dist = d, dist
+    end
+  end
+  return best
+end
+
+--- Slice out a diagram's fence (and its directive line) from a slide's lines,
+--- returning the remaining text-only lines.
+---@param slide {start, stop, lines}
+---@param diagram {open_row, close_row, directive_row}
+---@return string[]
+local function text_only_lines(slide, diagram)
+  local out = {}
+  for idx, line in ipairs(slide.lines) do
+    local abs = slide.start + idx - 1
+    local in_fence = abs >= diagram.open_row and abs <= diagram.close_row
+    local is_directive = abs == diagram.directive_row
+    if not in_fence and not is_directive then table.insert(out, line) end
+  end
+  return out
+end
+
+--- Fit an image into a cell box, preserving aspect. Falls back to 80% width.
+local function fit_image(img_w, img_h, max_cols, max_rows)
+  local image = require "md-render.image"
+  if img_w and img_h then
+    local c, r = image.calc_display_size(img_w, img_h, max_cols, max_rows)
+    if c and r then return c, r end
+  end
+  return math.max(1, math.floor(max_cols * 0.8)), math.min(max_rows, 15)
+end
+
+--- Build the rendered content for one slide under the given layouts.
+---@param slide {start, stop, lines}
+---@param opts {slide_w: integer, slide_h: integer, gap: integer?, layouts: table<integer, {kind,pct?}>?}
+---@return table content
+function M.build_slide_content(slide, opts)
+  local preview = require "md-render.preview"
+  local image = require "md-render.image"
+  local gap = opts.gap or 2
+  local layouts = opts.layouts or {}
+  local diagrams = M.find_diagrams(slide)
+
+  -- Choose the primary (non-fit) diagram, if any. v1 gives special layout to a
+  -- single diagram per slide; the rest render inline (fit).
+  local primary, primary_layout
+  for _, d in ipairs(diagrams) do
+    local layout = layouts[d.open_row] or M.effective_layout(slide, d)
+    if layout.kind ~= "fit" then
+      primary, primary_layout = d, layout
+      break
+    end
+  end
+
+  -- No special layout, or graphics unavailable: render the whole slide inline.
+  if not primary or not (image.supports_kitty() and image.has_mmdc()) then
+    return preview.build_content(slide.lines, { max_width = opts.slide_w })
+  end
+
+  local cached = image.get_mermaid_cached(primary.source)
+  local img_w, img_h
+  if cached then img_w, img_h = image.image_dimensions(cached) end
+
+  local body = text_only_lines(slide, primary)
+
+  if primary_layout.kind == "full" then
+    local content = preview.build_content(body, { max_width = opts.slide_w })
+    local rows_used = #content.lines
+    local box_rows = math.max(1, opts.slide_h - rows_used)
+    local cols, rows = fit_image(img_w, img_h, opts.slide_w, box_rows)
+    local col = math.max(0, math.floor((opts.slide_w - cols) / 2))
+    local img_line = rows_used
+    for _ = 1, rows do
+      table.insert(content.lines, "")
+    end
+    table.insert(content.image_placements, {
+      path = cached,
+      line = img_line,
+      col = col,
+      rows = rows,
+      cols = cols,
+      img_w = img_w,
+      img_h = img_h,
+      mermaid_source = not cached and primary.source or nil,
+    })
+    return content
+  end
+
+  -- left / right split.
+  local bands = PL.compute_bands(primary_layout.kind, primary_layout.pct or 50, opts.slide_w, gap)
+  local content = preview.build_content(body, {
+    max_width = bands.text.max_width,
+    indent = string.rep(" ", bands.text.indent),
+  })
+  local cols, rows = fit_image(img_w, img_h, bands.diagram.max_cols, opts.slide_h)
+  -- Ensure the buffer has enough rows for the image to overlay.
+  while #content.lines < rows do
+    table.insert(content.lines, "")
+  end
+  table.insert(content.image_placements, {
+    path = cached,
+    line = 0,
+    col = bands.diagram.col,
+    rows = rows,
+    cols = cols,
+    img_w = img_w,
+    img_h = img_h,
+    mermaid_source = not cached and primary.source or nil,
+  })
+  return content
+end
+
+--- Navigation state over `count` slides. idx is 1-indexed, clamped.
+---@param count integer
+---@return table nav
+function M.new_nav(count)
+  local nav = { idx = 1, count = math.max(1, count) }
+  function nav:goto(i)
+    self.idx = math.max(1, math.min(self.count, i))
+    return self.idx
+  end
+  function nav:next()
+    return self:goto(self.idx + 1)
+  end
+  function nav:prev()
+    return self:goto(self.idx - 1)
+  end
+  function nav:first()
+    return self:goto(1)
+  end
+  function nav:last()
+    return self:goto(self.count)
+  end
+  return nav
+end
+
+--- Save the editor chrome globals and window-local options the presenter
+--- overwrites, so quit can restore them.
+local function snapshot_chrome(win)
+  local wo = vim.wo[win]
+  return {
+    showtabline = vim.o.showtabline,
+    laststatus = vim.o.laststatus,
+    cmdheight = vim.o.cmdheight,
+    ruler = vim.o.ruler,
+    showcmd = vim.o.showcmd,
+    number = wo.number,
+    relativenumber = wo.relativenumber,
+    signcolumn = wo.signcolumn,
+    foldcolumn = wo.foldcolumn,
+    statuscolumn = wo.statuscolumn,
+    cursorline = wo.cursorline,
+    wrap = wo.wrap,
+    spell = wo.spell,
+    list = wo.list,
+    winbar = wo.winbar,
+  }
+end
+
+local function restore_chrome(win, s)
+  vim.o.showtabline = s.showtabline
+  vim.o.laststatus = s.laststatus
+  vim.o.cmdheight = s.cmdheight
+  vim.o.ruler = s.ruler
+  vim.o.showcmd = s.showcmd
+  if vim.api.nvim_win_is_valid(win) then
+    local wo = vim.wo[win]
+    wo.number = s.number
+    wo.relativenumber = s.relativenumber
+    wo.signcolumn = s.signcolumn
+    wo.foldcolumn = s.foldcolumn
+    wo.statuscolumn = s.statuscolumn
+    wo.cursorline = s.cursorline
+    wo.wrap = s.wrap
+    wo.spell = s.spell
+    wo.list = s.list
+    wo.winbar = s.winbar
+  end
+end
+
+M._snapshot_chrome = snapshot_chrome
+M._restore_chrome = restore_chrome
+
+--- Start the full-screen slideshow for the current buffer.
+---@param _opts? table
+function M.start(_opts)
+  local preview = require "md-render.preview"
+  local display_utils = require "md-render.display_utils"
+
+  local source_buf = vim.api.nvim_get_current_buf()
+  local source_win = vim.api.nvim_get_current_win()
+  if vim.b[source_buf].md_render_present then
+    vim.notify("md-render present: already presenting", vim.log.levels.INFO)
+    return
+  end
+  local source_lines = vim.api.nvim_buf_get_lines(source_buf, 0, -1, false)
+  local slides = M.segment(source_lines)
+  if #slides == 0 then
+    vim.notify("md-render present: no slides", vim.log.levels.WARN)
+    return
+  end
+
+  local nav = M.new_nav(#slides)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.b[buf].md_render_present = true
+  local ns = vim.api.nvim_create_namespace "md_render_present"
+  local layout_overrides = {} -- keyed by diagram open_row -> layout
+  local image_state = nil
+
+  local win = source_win
+  local chrome = snapshot_chrome(win)
+  vim.api.nvim_win_set_buf(win, buf)
+  preview.apply_pager_chrome(win, buf)
+
+  local function slide_dims()
+    local w = vim.api.nvim_win_get_width(win)
+    local info = vim.fn.getwininfo(win)[1]
+    local h = (info and info.height) or vim.api.nvim_win_get_height(win)
+    return w, h
+  end
+
+  local function render()
+    display_utils.cleanup_images(image_state) -- no-op on nil; deletes prior slide's images
+    local slide = slides[nav.idx]
+    local w, h = slide_dims()
+    local content = M.build_slide_content(slide, { slide_w = w, slide_h = h, layouts = layout_overrides })
+    vim.bo[buf].modifiable = true
+    vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+    display_utils.apply_content_to_buffer(buf, ns, content)
+    vim.bo[buf].modifiable = false
+    vim.wo[win].winbar = string.format("  %d / %d", nav.idx, #slides)
+    image_state = display_utils.setup_images(win, content, ns, {})
+    -- Prefetch neighbor mermaid renders so transitions are instant.
+    for _, j in ipairs { nav.idx - 1, nav.idx + 1 } do
+      if slides[j] then
+        for _, d in ipairs(M.find_diagrams(slides[j])) do
+          -- render_mermaid_async(source, callback) requires a callback; a no-op
+          -- is fine — we only want the cache populated for the neighbor slide.
+          pcall(function()
+            require("md-render.image").render_mermaid_async(d.source, function() end)
+          end)
+        end
+      end
+    end
+  end
+
+  local function quit()
+    display_utils.cleanup_images(image_state) -- no-op on nil; deletes prior slide's images
+    restore_chrome(win, chrome)
+    if vim.api.nvim_win_is_valid(win) and vim.api.nvim_buf_is_valid(source_buf) then
+      vim.api.nvim_win_set_buf(win, source_buf)
+    end
+    if vim.api.nvim_buf_is_valid(buf) then vim.api.nvim_buf_delete(buf, { force = true }) end
+  end
+
+  local function map(lhs, fn)
+    vim.keymap.set("n", lhs, fn, { buffer = buf, nowait = true, silent = true })
+  end
+  for _, k in ipairs { "n", "<Right>", "<Space>", "<PageDown>" } do
+    map(k, function()
+      nav:next()
+      render()
+    end)
+  end
+  for _, k in ipairs { "p", "<Left>", "<PageUp>" } do
+    map(k, function()
+      nav:prev()
+      render()
+    end)
+  end
+  map("gg", function()
+    nav:first()
+    render()
+  end)
+  map("G", function()
+    nav:last()
+    render()
+  end)
+  for _, k in ipairs { "q", "<Esc>", "<C-c>" } do
+    map(k, quit)
+  end
+
+  -- Layout toggle keys (Task 10 fills in toggle_current / nudge_current).
+  map("L", function()
+    M.toggle_current(slides, nav, source_buf, layout_overrides, render)
+  end)
+  map("<", function()
+    M.nudge_current(slides, nav, source_buf, layout_overrides, render, -5)
+  end)
+  map(">", function()
+    M.nudge_current(slides, nav, source_buf, layout_overrides, render, 5)
+  end)
+
+  render()
+end
+
+--- Resolve the nearest diagram on the current slide, transform its layout,
+--- record the override, and persist the directive to the source buffer.
+---@param slides table[]
+---@param nav {idx: integer}
+---@param source_buf integer
+---@param overrides table<integer, {kind,pct?}>
+---@param cursor_row integer  1-indexed source row
+---@param transform fun(layout: {kind,pct?}): {kind,pct?}
+---@return {kind: string, pct: integer?}|nil
+function M.apply_layout_change(slides, nav, source_buf, overrides, cursor_row, transform)
+  local slide = slides[nav.idx]
+  local diagrams = M.find_diagrams(slide)
+  local d = M.nearest_diagram(diagrams, cursor_row)
+  if not d then return nil end
+  local current = overrides[d.open_row] or M.effective_layout(slide, d)
+  local new_layout = transform(current)
+  local new_open = M.write_diagram_layout(source_buf, d, new_layout)
+  if new_open then
+    -- Persistence shifted source rows; re-segment and re-key by the new row.
+    overrides[new_open] = new_layout
+    local fresh = M.segment(vim.api.nvim_buf_get_lines(source_buf, 0, -1, false))
+    for k in pairs(slides) do
+      slides[k] = fresh[k]
+    end
+  else
+    -- Read-only / non-file source: keep it ephemeral.
+    overrides[d.open_row] = new_layout
+    vim.notify("md-render present: layout not persisted (buffer is read-only)", vim.log.levels.INFO)
+  end
+  return new_layout
+end
+
+--- Window-bound wrappers used by the presenter keymaps.
+function M.toggle_current(slides, nav, source_buf, overrides, rerender)
+  local cursor_row = vim.api.nvim_win_get_cursor(0)[1]
+  M.apply_layout_change(slides, nav, source_buf, overrides, cursor_row, PL.cycle)
+  rerender()
+end
+
+function M.nudge_current(slides, nav, source_buf, overrides, rerender, delta)
+  local cursor_row = vim.api.nvim_win_get_cursor(0)[1]
+  M.apply_layout_change(slides, nav, source_buf, overrides, cursor_row, function(l)
+    return PL.nudge(l, delta)
+  end)
+  rerender()
+end
+
+return M

--- a/lua/md-render/presenter_layout.lua
+++ b/lua/md-render/presenter_layout.lua
@@ -1,0 +1,88 @@
+--- Pure layout geometry + cycle math for presenter mode. No vim/state deps.
+local M = {}
+
+M.MIN_PCT = 20
+M.MAX_PCT = 80
+
+-- Cycle order by kind; left/right carry a percent.
+local CYCLE = { "fit", "left", "right", "full" }
+
+local function clamp_pct(p)
+  if p < M.MIN_PCT then return M.MIN_PCT end
+  if p > M.MAX_PCT then return M.MAX_PCT end
+  return p
+end
+
+--- Parse a layout string into a layout table, or nil if unrecognized.
+---@param str string
+---@return {kind: string, pct: integer?}|nil
+function M.parse_layout(str)
+  if type(str) ~= "string" then return nil end
+  local s = str:gsub("%s", ""):lower()
+  if s == "full" then return { kind = "full" } end
+  if s == "fit" then return { kind = "fit" } end
+  local side, pct = s:match "^(left):(%d+)$"
+  if not side then
+    side, pct = s:match "^(right):(%d+)$"
+  end
+  if side then return { kind = side, pct = clamp_pct(tonumber(pct)) } end
+  if s == "left" or s == "right" then return { kind = s, pct = 50 } end
+  return nil
+end
+
+--- Serialize a layout table to its directive string form.
+---@param layout {kind: string, pct: integer?}
+---@return string
+function M.serialize_layout(layout)
+  if layout.kind == "left" or layout.kind == "right" then return layout.kind .. ":" .. tostring(layout.pct or 50) end
+  return layout.kind
+end
+
+--- Next layout in the cycle (fit -> left:50 -> right:50 -> full -> fit).
+---@param layout {kind: string, pct: integer?}
+---@return {kind: string, pct: integer?}
+function M.cycle(layout)
+  local idx = 1
+  for i, k in ipairs(CYCLE) do
+    if k == layout.kind then
+      idx = i
+      break
+    end
+  end
+  local next_kind = CYCLE[(idx % #CYCLE) + 1]
+  if next_kind == "left" or next_kind == "right" then return { kind = next_kind, pct = 50 } end
+  return { kind = next_kind }
+end
+
+--- Adjust the split percentage (left/right only), clamped. No-op otherwise.
+---@param layout {kind: string, pct: integer?}
+---@param delta integer
+---@return {kind: string, pct: integer?}
+function M.nudge(layout, delta)
+  if layout.kind ~= "left" and layout.kind ~= "right" then return layout end
+  return { kind = layout.kind, pct = clamp_pct((layout.pct or 50) + delta) }
+end
+
+--- Column bands for a split layout. `gap` cells separate diagram and text.
+---@param kind "left"|"right"
+---@param pct integer
+---@param slide_w integer usable text-area width in cells
+---@param gap integer
+---@return {text: {indent: integer, max_width: integer}, diagram: {col: integer, max_cols: integer}}
+function M.compute_bands(kind, pct, slide_w, gap)
+  local d_cols = math.floor(slide_w * pct / 100)
+  if kind == "left" then
+    local indent = d_cols + gap
+    return {
+      diagram = { col = 0, max_cols = d_cols },
+      text = { indent = indent, max_width = slide_w - indent },
+    }
+  end
+  -- right
+  return {
+    diagram = { col = slide_w - d_cols, max_cols = d_cols },
+    text = { indent = 0, max_width = slide_w - d_cols - gap },
+  }
+end
+
+return M

--- a/lua/md-render/preview.lua
+++ b/lua/md-render/preview.lua
@@ -655,6 +655,29 @@ end
 -- show_pager: full-screen pager mode (existing behavior)
 -- =====================================================================
 
+--- Apply full-screen "no chrome" window/editor options (pager & presenter).
+---@param win integer
+---@param buf integer
+function MdPreview.apply_pager_chrome(win, buf)
+  vim.o.showtabline = 0
+  vim.o.laststatus = 0
+  vim.o.cmdheight = 0
+  vim.o.ruler = false
+  vim.o.showcmd = false
+  vim.wo[win].number = false
+  vim.wo[win].relativenumber = false
+  vim.wo[win].signcolumn = "no"
+  vim.wo[win].foldcolumn = "0"
+  vim.wo[win].statuscolumn = ""
+  vim.wo[win].cursorline = true
+  vim.wo[win].wrap = true
+  vim.wo[win].spell = false
+  vim.wo[win].list = false
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].bufhidden = "wipe"
+  vim.bo[buf].buftype = "nofile"
+end
+
 --- Show markdown in pager mode (full-screen, minimal UI, q to quit Neovim)
 ---@param opts? { max_width?: integer }
 MdPreview.show_pager = function(opts)
@@ -670,26 +693,7 @@ MdPreview.show_pager = function(opts)
   local win = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_buf(win, session.buf)
 
-  -- Hide all chrome for pager feel
-  vim.o.showtabline = 0
-  vim.o.laststatus = 0
-  vim.o.cmdheight = 0
-  vim.o.ruler = false
-  vim.o.showcmd = false
-
-  vim.wo[win].number = false
-  vim.wo[win].relativenumber = false
-  vim.wo[win].signcolumn = "no"
-  vim.wo[win].foldcolumn = "0"
-  vim.wo[win].statuscolumn = ""
-  vim.wo[win].cursorline = true
-  vim.wo[win].wrap = true
-  vim.wo[win].spell = false
-  vim.wo[win].list = false
-
-  vim.bo[session.buf].modifiable = false
-  vim.bo[session.buf].bufhidden = "wipe"
-  vim.bo[session.buf].buftype = "nofile"
+  MdPreview.apply_pager_chrome(win, session.buf)
 
   session:bind_window(win)
 
@@ -778,6 +782,12 @@ MdPreview.show_pager = function(opts)
 
     try_open_url()
   end, { buffer = session.buf, noremap = true, silent = true })
+end
+
+--- Enter full-screen presenter mode for the current markdown buffer.
+---@param opts? table
+MdPreview.show_present = function(opts)
+  require("md-render.presenter").start(opts)
 end
 
 -- =====================================================================

--- a/plugin/md-render.lua
+++ b/plugin/md-render.lua
@@ -25,13 +25,17 @@ vim.keymap.set("n", "<Plug>(md-render-demo)", function()
   require("md-render").preview.show_demo()
 end, { desc = "Markdown render demo" })
 
+vim.keymap.set("n", "<Plug>(md-render-present)", function()
+  require("md-render").preview.show_present()
+end, { desc = "Markdown presenter (slideshow)" })
+
 local cmd = require "md-render.command"
 
 vim.api.nvim_create_user_command("MdRender", cmd.dispatch, {
   nargs = "*",
   complete = cmd.complete,
   bar = true,
-  desc = "Markdown render — :MdRender [float|tab|pager|toggle|split|auto on|off|toggle|demo]",
+  desc = "Markdown render — :MdRender [float|tab|pager|toggle|split|auto on|off|toggle|demo|present]",
 })
 
 --- Register a deprecated v3 shim that forwards to the new dispatcher.

--- a/tests/command_test.lua
+++ b/tests/command_test.lua
@@ -208,7 +208,7 @@ test("complete first arg empty -> all subcommands", function()
   -- Order matches the SUBCOMMANDS table
   assert_eq(
     out,
-    { "float", "tab", "pager", "toggle", "split", "auto", "demo" },
+    { "float", "tab", "pager", "toggle", "split", "auto", "demo", "present" },
     "all subcommands returned for empty arglead"
   )
   restore()
@@ -240,7 +240,7 @@ test("complete tolerates :vert mod prefix", function()
   local out = cmd.complete("", "vert MdRender ", #"vert MdRender ")
   assert_eq(
     out,
-    { "float", "tab", "pager", "toggle", "split", "auto", "demo" },
+    { "float", "tab", "pager", "toggle", "split", "auto", "demo", "present" },
     "leading :vert mod still yields full subcommand list"
   )
   restore()
@@ -276,6 +276,28 @@ test("deprecated wrapper warns once and forwards args", function()
   assert_true(notif[1].msg:match "MdRender toggle", "warning suggests the new form")
   restore_n()
   restore()
+end)
+
+test("complete: lists 'present' as a subcommand", function()
+  local cmd = require "md-render.command"
+  local out = cmd.complete("pr", "MdRender pr", 11)
+  local found = false
+  for _, s in ipairs(out) do
+    if s == "present" then found = true end
+  end
+  assert_eq(found, true, "'present' offered in completion")
+end)
+
+test("dispatch: 'present' calls show_present", function()
+  package.loaded["md-render"] = package.loaded["md-render"] or {}
+  local called = false
+  local fake = { show_present = function() called = true end }
+  local md = require "md-render"
+  local saved = rawget(md, "preview")
+  rawset(md, "preview", fake)
+  require("md-render.command").dispatch { fargs = { "present" } }
+  rawset(md, "preview", saved)
+  assert_eq(called, true, "dispatch routed to show_present")
 end)
 
 print(string.format("command_test: %d passed, %d failed", pass_count, fail_count))

--- a/tests/presenter_test.lua
+++ b/tests/presenter_test.lua
@@ -1,0 +1,341 @@
+-- Run: nvim --headless -u NONE --noplugin -l tests/presenter_test.lua
+package.path = vim.fn.getcwd() .. "/lua/?.lua;" .. vim.fn.getcwd() .. "/lua/?/init.lua;" .. package.path
+
+local pass_count = 0
+local fail_count = 0
+
+local function assert_eq(actual, expected, msg)
+  if vim.deep_equal(actual, expected) then
+    pass_count = pass_count + 1
+  else
+    fail_count = fail_count + 1
+    print("FAIL: " .. msg)
+    print("  expected: " .. vim.inspect(expected))
+    print("  actual:   " .. vim.inspect(actual))
+  end
+end
+
+local function test(name, fn)
+  local ok, err = pcall(fn)
+  if not ok then
+    fail_count = fail_count + 1
+    print("ERROR: " .. name .. ": " .. tostring(err))
+  end
+end
+
+local PL = require "md-render.presenter_layout"
+
+test("parse_layout: forms", function()
+  assert_eq(PL.parse_layout "full", { kind = "full" }, "full")
+  assert_eq(PL.parse_layout "fit", { kind = "fit" }, "fit")
+  assert_eq(PL.parse_layout "left", { kind = "left", pct = 50 }, "left defaults 50")
+  assert_eq(PL.parse_layout "left:40", { kind = "left", pct = 40 }, "left:40")
+  assert_eq(PL.parse_layout "RIGHT:35", { kind = "right", pct = 35 }, "case-insensitive")
+  assert_eq(PL.parse_layout "bogus", nil, "unknown -> nil")
+end)
+
+test("serialize_layout: round-trip", function()
+  assert_eq(PL.serialize_layout { kind = "full" }, "full", "full")
+  assert_eq(PL.serialize_layout { kind = "left", pct = 40 }, "left:40", "left:40")
+  assert_eq(PL.serialize_layout { kind = "fit" }, "fit", "fit")
+end)
+
+test("cycle: fit -> left:50 -> right:50 -> full -> fit", function()
+  assert_eq(PL.cycle { kind = "fit" }, { kind = "left", pct = 50 }, "fit->left")
+  assert_eq(PL.cycle { kind = "left", pct = 40 }, { kind = "right", pct = 50 }, "left->right")
+  assert_eq(PL.cycle { kind = "right", pct = 50 }, { kind = "full" }, "right->full")
+  assert_eq(PL.cycle { kind = "full" }, { kind = "fit" }, "full->fit")
+end)
+
+test("nudge: only left/right, clamped", function()
+  assert_eq(PL.nudge({ kind = "left", pct = 50 }, 5), { kind = "left", pct = 55 }, "nudge +5")
+  assert_eq(PL.nudge({ kind = "left", pct = 80 }, 5), { kind = "left", pct = 80 }, "clamp high")
+  assert_eq(PL.nudge({ kind = "right", pct = 20 }, -5), { kind = "right", pct = 20 }, "clamp low")
+  assert_eq(PL.nudge({ kind = "full" }, 5), { kind = "full" }, "full unaffected")
+end)
+
+test("compute_bands: left:40 slide_w=100 gap=2", function()
+  local b = PL.compute_bands("left", 40, 100, 2)
+  assert_eq(b.diagram, { col = 0, max_cols = 40 }, "left diagram at col 0 width 40")
+  assert_eq(b.text, { indent = 42, max_width = 58 }, "left text indent 42 width 58")
+end)
+
+test("compute_bands: right:40 slide_w=100 gap=2", function()
+  local b = PL.compute_bands("right", 40, 100, 2)
+  assert_eq(b.diagram, { col = 60, max_cols = 40 }, "right diagram at col 60 width 40")
+  assert_eq(b.text, { indent = 0, max_width = 58 }, "right text indent 0 width 58")
+end)
+
+local P = require "md-render.presenter"
+
+test("segment: splits on top-level ---", function()
+  local slides = P.segment { "# A", "x", "---", "# B", "y" }
+  assert_eq(#slides, 2, "two slides")
+  assert_eq(slides[1].lines, { "# A", "x" }, "slide 1 lines")
+  assert_eq(slides[2].lines, { "# B", "y" }, "slide 2 lines")
+  assert_eq(slides[2].start, 4, "slide 2 starts at source row 4")
+end)
+
+test("segment: --- inside code fence is not a split", function()
+  local slides = P.segment { "# A", "```", "---", "```", "done" }
+  assert_eq(#slides, 1, "fence-internal --- ignored")
+end)
+
+test("segment: --- inside a [//]: # comment is not a split", function()
+  local slides = P.segment { "a", "[//]: # (---)", "b" }
+  assert_eq(#slides, 1, "comment --- ignored")
+end)
+
+test("find_diagrams: captures source, directive, layout", function()
+  local slide = P.segment({
+    "# Title",
+    "[//]: # (diagram: left:40)",
+    "```mermaid",
+    "flowchart LR",
+    "  A --> B",
+    "```",
+    "notes",
+  })[1]
+  local ds = P.find_diagrams(slide)
+  assert_eq(#ds, 1, "one diagram")
+  assert_eq(ds[1].source, "flowchart LR\n  A --> B", "mermaid source captured")
+  assert_eq(ds[1].open_row, 3, "open fence row")
+  assert_eq(ds[1].directive_row, 2, "directive row")
+  assert_eq(ds[1].layout, { kind = "left", pct = 40 }, "explicit layout parsed")
+end)
+
+test("find_diagrams: no directive -> layout nil", function()
+  local slide = P.segment({ "```mermaid", "graph TD", "```" })[1]
+  local ds = P.find_diagrams(slide)
+  assert_eq(ds[1].layout, nil, "no explicit layout")
+end)
+
+test("find_diagrams: stray fence of other type does not truncate body", function()
+  local slide = P.segment({ "```mermaid", "graph TD", "~~~", "A-->B", "```" })[1]
+  local ds = P.find_diagrams(slide)
+  assert_eq(#ds, 1, "one diagram")
+  assert_eq(ds[1].source, "graph TD\n~~~\nA-->B", "stray ~~~ kept in body")
+  assert_eq(ds[1].close_row, 5, "closes at matching backtick fence")
+end)
+
+test("parse_deck_options: first deck comment wins", function()
+  local opts = P.parse_deck_options { "[//]: # (deck: max-width=90 theme=fit)", "# A" }
+  assert_eq(opts["max-width"], "90", "max-width parsed")
+  assert_eq(opts["theme"], "fit", "theme parsed")
+end)
+
+test("parse_deck_options: none -> empty", function()
+  assert_eq(P.parse_deck_options { "# A" }, {}, "no deck comment")
+end)
+
+test("default_layout: solo diagram -> full", function()
+  local slide = P.segment({ "```mermaid", "graph TD", "```" })[1]
+  assert_eq(P.default_layout(slide), { kind = "full" }, "solo -> full")
+end)
+
+test("default_layout: diagram + text -> fit", function()
+  local slide = P.segment({ "# Title", "```mermaid", "graph TD", "```", "body text" })[1]
+  assert_eq(P.default_layout(slide), { kind = "fit" }, "mixed -> fit")
+end)
+
+test("effective_layout: explicit beats default", function()
+  local slide = P.segment({ "[//]: # (diagram: right:30)", "```mermaid", "g", "```" })[1]
+  local d = P.find_diagrams(slide)[1]
+  assert_eq(P.effective_layout(slide, d), { kind = "right", pct = 30 }, "explicit wins")
+end)
+
+local function scratch_buf(lines)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  return buf
+end
+
+test("write_diagram_layout: inserts a new directive above the fence", function()
+  local buf = scratch_buf { "# Title", "```mermaid", "g", "```" }
+  local slide = P.segment(vim.api.nvim_buf_get_lines(buf, 0, -1, false))[1]
+  local d = P.find_diagrams(slide)[1]
+  local new_open = P.write_diagram_layout(buf, d, { kind = "left", pct = 40 })
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  assert_eq(lines[2], "[//]: # (diagram: left:40)", "directive inserted at row 2")
+  assert_eq(new_open, 3, "fence shifted down to row 3")
+end)
+
+test("write_diagram_layout: replaces an existing directive", function()
+  local buf = scratch_buf { "[//]: # (diagram: left:40)", "```mermaid", "g", "```" }
+  local slide = P.segment(vim.api.nvim_buf_get_lines(buf, 0, -1, false))[1]
+  local d = P.find_diagrams(slide)[1]
+  local new_open = P.write_diagram_layout(buf, d, { kind = "right", pct = 25 })
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  assert_eq(lines[1], "[//]: # (diagram: right:25)", "directive replaced in place")
+  assert_eq(new_open, 2, "fence row unchanged")
+  assert_eq(#lines, 4, "no line added on replace")
+end)
+
+test("write_diagram_layout: read-only buffer returns nil", function()
+  local buf = scratch_buf { "```mermaid", "g", "```" }
+  vim.bo[buf].modifiable = false
+  local slide = P.segment { "```mermaid", "g", "```" }[1]
+  local d = P.find_diagrams(slide)[1]
+  assert_eq(P.write_diagram_layout(buf, d, { kind = "full" }), nil, "nil on read-only")
+end)
+
+test("nearest_diagram: picks closest by open_row", function()
+  local diagrams = { { open_row = 3 }, { open_row = 20 } }
+  assert_eq(P.nearest_diagram(diagrams, 18).open_row, 20, "cursor near second")
+  assert_eq(P.nearest_diagram(diagrams, 5).open_row, 3, "cursor near first")
+end)
+
+test("nearest_diagram: empty -> nil", function()
+  assert_eq(P.nearest_diagram({}, 1), nil, "no diagrams")
+end)
+
+local function with_image_stub(cached_path, img_w, img_h, fn)
+  local image = require "md-render.image"
+  local saved = {
+    supports_kitty = image.supports_kitty,
+    has_mmdc = image.has_mmdc,
+    get_mermaid_cached = image.get_mermaid_cached,
+    image_dimensions = image.image_dimensions,
+  }
+  image.supports_kitty = function() return true end
+  image.has_mmdc = function() return true end
+  image.get_mermaid_cached = function() return cached_path end
+  image.image_dimensions = function() return img_w, img_h end
+  local ok, err = pcall(fn)
+  for k, v in pairs(saved) do
+    image[k] = v
+  end
+  if not ok then error(err) end
+end
+
+test("build_slide_content: left:40 places image left, text indented", function()
+  with_image_stub("/tmp/fake.png", 400, 300, function()
+    local slide = P.segment({
+      "[//]: # (diagram: left:40)",
+      "```mermaid",
+      "flowchart LR",
+      "```",
+      "some explanatory body text that should wrap into the right column band",
+    })[1]
+    local content = P.build_slide_content(slide, { slide_w = 100, slide_h = 30, gap = 2 })
+    assert_eq(#content.image_placements, 1, "one image placement")
+    assert_eq(content.image_placements[1].col, 0, "diagram in left band at col 0")
+    -- text lines are prefixed by the 42-cell indent (diagram 40 + gap 2)
+    local indented = false
+    for _, l in ipairs(content.lines) do
+      if l:match "%S" then
+        indented = l:match "^%s%s+" ~= nil and (#l:match "^ *") >= 42
+        if indented then break end
+      end
+    end
+    assert_eq(indented, true, "body text indented into the right column")
+  end)
+end)
+
+test("build_slide_content: fit passes through inline rendering", function()
+  with_image_stub("/tmp/fake.png", 400, 300, function()
+    local slide = P.segment({ "# T", "text", "[//]: # (diagram: fit)", "```mermaid", "g", "```" })[1]
+    local content = P.build_slide_content(slide, { slide_w = 80, slide_h = 24 })
+    -- inline mermaid emits a placement centered (col > 0 for an 80-wide slide)
+    assert_eq(#content.image_placements >= 1, true, "inline placement present")
+  end)
+end)
+
+test("new_nav: clamps and moves", function()
+  local nav = P.new_nav(3)
+  assert_eq(nav.idx, 1, "starts at 1")
+  assert_eq(nav:next(), 2, "next -> 2")
+  assert_eq(nav:next(), 3, "next -> 3")
+  assert_eq(nav:next(), 3, "next clamps at count")
+  assert_eq(nav:prev(), 2, "prev -> 2")
+  assert_eq(nav:last(), 3, "last -> 3")
+  assert_eq(nav:first(), 1, "first -> 1")
+  assert_eq(nav:goto(99), 3, "goto clamps high")
+  assert_eq(nav:goto(-1), 1, "goto clamps low")
+end)
+
+test("apply_pager_chrome: sets buffer nofile + non-modifiable", function()
+  local preview = require "md-render.preview"
+  local buf = vim.api.nvim_create_buf(false, true)
+  local win = vim.api.nvim_get_current_win()
+  preview.apply_pager_chrome(win, buf)
+  assert_eq(vim.bo[buf].buftype, "nofile", "buftype nofile")
+  assert_eq(vim.bo[buf].modifiable, false, "not modifiable")
+end)
+
+test("snapshot/restore chrome round-trips window-local options + winbar", function()
+  local win = vim.api.nvim_get_current_win()
+  vim.wo[win].number = true
+  vim.wo[win].winbar = "orig"
+  vim.wo[win].cursorline = false
+  local snap = P._snapshot_chrome(win)
+  -- mutate as presenter would
+  vim.wo[win].number = false
+  vim.wo[win].winbar = "2 / 8"
+  vim.wo[win].cursorline = true
+  P._restore_chrome(win, snap)
+  assert_eq(vim.wo[win].number, true, "number restored")
+  assert_eq(vim.wo[win].winbar, "orig", "winbar restored")
+  assert_eq(vim.wo[win].cursorline, false, "cursorline restored")
+end)
+
+test("apply_layout_change: cycles nearest diagram and persists comment", function()
+  local buf = scratch_buf { "# T", "```mermaid", "g", "```", "text" }
+  local slides = P.segment(vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+  local nav = P.new_nav(#slides)
+  local overrides = {}
+  -- default for a mixed slide is "fit"; cycle -> left:50
+  local new_layout = P.apply_layout_change(slides, nav, buf, overrides, 2, require("md-render.presenter_layout").cycle)
+  assert_eq(new_layout, { kind = "left", pct = 50 }, "fit cycles to left:50")
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local has_directive = false
+  for _, l in ipairs(lines) do
+    if l == "[//]: # (diagram: left:50)" then has_directive = true end
+  end
+  assert_eq(has_directive, true, "directive written to source buffer")
+  -- override recorded by open_row (fence shifted to row 3 after insert)
+  assert_eq(overrides[3], { kind = "left", pct = 50 }, "override keyed by new open_row")
+end)
+
+test("apply_layout_change: no diagram -> nil", function()
+  local buf = scratch_buf { "just text", "more" }
+  local slides = P.segment(vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+  local nav = P.new_nav(#slides)
+  assert_eq(P.apply_layout_change(slides, nav, buf, {}, 1, require("md-render.presenter_layout").cycle), nil, "nil")
+end)
+
+test("segment: drops all-blank slides from leading/trailing/consecutive ---", function()
+  local slides = P.segment { "---", "# A", "---", "---", "# B", "---" }
+  assert_eq(#slides, 2, "only two non-blank slides")
+  assert_eq(slides[1].lines, { "# A" }, "slide 1 is # A")
+  assert_eq(slides[2].lines, { "# B" }, "slide 2 is # B")
+end)
+
+test("build_slide_content: right:40 places image in the right band", function()
+  with_image_stub("/tmp/fake.png", 400, 300, function()
+    local slide = P.segment({
+      "[//]: # (diagram: right:40)",
+      "```mermaid",
+      "flowchart LR",
+      "```",
+      "body text on the left half of the slide",
+    })[1]
+    local content = P.build_slide_content(slide, { slide_w = 100, slide_h = 30, gap = 2 })
+    assert_eq(#content.image_placements, 1, "one image placement")
+    assert_eq(content.image_placements[1].col, 60, "diagram in right band at col 60")
+  end)
+end)
+
+test("build_slide_content: full (solo diagram) places one centered image at line 0", function()
+  with_image_stub("/tmp/fake.png", 400, 300, function()
+    local slide = P.segment({ "```mermaid", "graph TD", "```" })[1]
+    local content = P.build_slide_content(slide, { slide_w = 80, slide_h = 24 })
+    assert_eq(#content.image_placements, 1, "one image placement")
+    assert_eq(content.image_placements[1].line, 0, "solo full: image at line 0 (empty body)")
+  end)
+end)
+
+-- Summary footer — MUST stay the last two lines of this file. Later tasks
+-- insert their test(...) blocks ABOVE this footer (see Global Constraints).
+print(string.format("\n%d passed, %d failed", pass_count, fail_count))
+if fail_count > 0 then os.exit(1) end


### PR DESCRIPTION
:MdRender present — a full-screen, one-slide-per-screen presenter. --- splits slides; Mermaid renders inline as images;
  n/p/arrows/Space/PageUp-Down/gg/G navigate; L cycles a diagram's layout (fit → left → right → full) and </> nudge the split %, persisting the choice as
  a hidden [//]: # (diagram: …) comment written back to the file. Two new modules (presenter_layout.lua, presenter.lua), plus command/<Plug>/docs wiring.
  content_builder.lua was left untouched — the split layout is composed presenter-side, as the plan intended.