### PR TITLE
feat(preview): show a status footer on the floating preview's border

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,6 +20,7 @@ Neovim 用の Markdown レンダリングエンジンです。生の Markdown �
 - **CJK 対応ワードラップ** — JIS X 4051 禁則処理 + [BudouX](https://github.com/google/budoux)（[budoux.lua](https://github.com/delphinus/budoux.lua) 経由）によるオプションのフレーズ分割
 - **クリック可能リンク** — マウスクリックで URL を開く。対応ターミナルでは OSC 8 ハイパーリンク
 - **`<details>` 対応** — クリックまたは `za` / `<CR>` で折りたたみ可能なセクション。`open` 属性にも対応
+- **ステータスフッタ** — フローティングプレビューの下ボーダーにファイル名・ソース内の現在位置・罫線素片のプログレスバーを表示。本文の行を消費せず、ステータスラインにも干渉しない
 - **ライブラリ API** — レンダリングエンジンを自作プラグインからプログラム的に利用可能
 
 <figure align="center">

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Markdown rendering engine for Neovim. Transforms raw Markdown into richly high
 - **CJK-aware word wrapping** — JIS X 4051 kinsoku shori + optional [BudouX](https://github.com/google/budoux) phrase segmentation via [budoux.lua](https://github.com/delphinus/budoux.lua)
 - **Clickable links** — mouse click to open URLs; hover the mouse over a link to peek the full URL in a subtle floating window; OSC 8 hyperlink support for compatible terminals
 - **`<details>` support** — collapsible sections you can toggle by clicking or with `za` / `<CR>`, respecting the `open` attribute
+- **Status footer** — the floating preview shows the file name, your position in the source, and a box-drawing progress bar on its bottom border, without stealing a content row or touching your statusline
 - **Library API** — use the rendering engine programmatically from your own plugins
 
 <figure align="center">

--- a/doc/md-render.jax
+++ b/doc/md-render.jax
@@ -491,6 +491,13 @@ grep 系の picker では、マッチしたソース行に自動スクロール�
 MdPreview.show({opts}) ~
 	現在の Markdown バッファのフローティングプレビューをトグルします。
 
+	下ボーダーにはステータスフッタが表示されます。内容はソースのファイル名、
+	カーソル位置が対応するソースの行、そして罫線素片で描いたプログレスバー
+	です: >
+	  ╰──────────── README.md   25/100  ━━╾─────── ╯
+<	カーソルに追従し、ウィンドウの幅が足りないときはバー、位置の順に省略され
+	ます。|md-render-float-footer| を参照してください。
+
 	パラメータ: ~
 	  {opts}  (table|nil) オプション設定:
 		  - {max_width}  (integer) 最大レンダリング幅
@@ -725,6 +732,56 @@ display_utils.open_float_window({buf}, {content}, {float_win}, {opts}) ~
 	レンダリング済みコンテンツ用のフローティングウィンドウを作成・配置しま
 	す。
 
+	パラメータ: ~
+	  {opts}  (table|nil) オプション設定:
+		  - {title}     (string) ボーダーのタイトル
+		  - {position}  ("mouse"|"center") 配置
+		  - {enter}     (boolean) ウィンドウにフォーカスするか
+		  - {footer}    (table[]) 下ボーダーに表示する chunk のリス
+		    ト。通常は |display_utils.build_footer_chunks()| の戻り値
+
+					  *display_utils.build_footer_chunks()*
+					  *md-render-float-footer*
+display_utils.build_footer_chunks({info}, {width}) ~
+	フローティングウィンドウのステータスフッタ用に `{text, hl_group}` の
+	chunk リストを作ります。
+
+	ステータスラインではなくボーダーの footer を使うのは、フローティング
+	ウィンドウが 'laststatus' の値が 1 か 2 のときしかステータスラインを描
+	画しないためです。'laststatus' が 3（lualine の `globalstatus` オプショ
+	ンが設定する値）のときは、フローティングウィンドウのウィンドウローカル
+	な 'statusline' が画面下端のグローバルなステータスラインとして使われる
+	ので、情報が表示されないばかりか、ユーザのステータスラインを上書きして
+	しまいます。footer は常に描画され、本文の行を消費しません。
+
+	レイアウトは `<name>  <line>/<total>  <bar>` です。バーは 10 セル幅で、
+	罫線素片で描かれます（通過済みの部分が `━` 、残りが `─` 、半セル分が
+	`╾` ）。細線の側はボーダー自身と同じ字なので、未達の部分はウィジェット
+	ではなくボーダーの続きとして見えます。
+
+	行番号は {total} の桁数に合わせて右寄せされるので、スクロールしても
+	フッタの幅は変わりません。{width} に収まらないときは、まずバーが最小 4
+	セルまで縮み、それでも収まらなければ右側のセグメント（バー → 位置 →
+	ファイル名の順）から削られます。幅は表示セル単位で測るので、CJK のファ
+	イル名も正しく扱えます。
+
+	パラメータ: ~
+	  {info}   (table) 表示するセグメント:
+		   - {name}   (string|nil) ファイル名
+		   - {line}   (integer|nil) 現在行（{total} でクランプ）
+		   - {total}  (integer|nil) 総行数
+	  {width}  (integer) フローティングウィンドウの内側の幅
+
+	戻り値: ~
+	  (table[]) chunk リスト。何も収まらない場合は空。
+
+					     *display_utils.set_float_footer()*
+display_utils.set_float_footer({win}, {chunks}, {pos}) ~
+	|display_utils.build_footer_chunks()| で作った footer をフローティング
+	ウィンドウに適用します。{pos} の既定値は `"right"` です。無効なウィンド
+	ウや非フローティングウィンドウでは何もしないので、タブ・分割・ページャー
+	表示と同じコードから呼べます。
+
 					   *display_utils.setup_float_keymaps()*
 display_utils.setup_float_keymaps({buf}, {ns}, {win}, {content}, ...) ~
 	フローティングウィンドウでインタラクティブなキーマップ（リン
@@ -861,6 +918,18 @@ Details ~
 
   *MdRenderImagePlaceholder*
                         画像読み込み中に表示されるプレースホルダー
+
+フローティングウィンドウの footer ~
+
+  *MdRenderFooter*      フローティングプレビューの下ボーダーに表示される
+                        ステータス情報（ `FloatFooter` にリンク）
+  *MdRenderFooterName*  その footer のファイル名部分
+                        （ `FloatTitle` にリンク）
+  *MdRenderFooterBar*   プログレスバーの通過済みの部分
+                        （ `FloatTitle` にリンク）
+							*MdRenderFooterBarEmpty*
+                        プログレスバーの残りの部分。描画先のボーダーに
+                        溶け込むよう `FloatBorder` にリンクしている
 
 分割モード ~
 

--- a/doc/md-render.txt
+++ b/doc/md-render.txt
@@ -486,6 +486,14 @@ PREVIEW							     *md-render-preview*
 MdPreview.show({opts}) ~
 	Toggle a floating preview window for the current Markdown buffer.
 
+	The bottom border carries a status footer with the source file name,
+	the source line the cursor maps back to, and a progress bar drawn
+	from box-drawing pieces: >
+	  ╰──────────── README.md   25/100  ━━╾─────── ╯
+<	It follows the cursor and shrinks — the bar first, then the whole
+	position — when the window is too narrow.  See
+	|md-render-float-footer|.
+
 	Parameters: ~
 	  {opts}  (table|nil) Optional settings:
 		  - {max_width}  (integer) Maximum rendering width
@@ -721,6 +729,57 @@ display_utils.apply_treesitter_highlights({buf}, {ns}, {content}) ~
 display_utils.open_float_window({buf}, {content}, {float_win}, {opts}) ~
 	Create and position a floating window for rendered content.
 
+	Parameters: ~
+	  {opts}  (table|nil) Optional settings:
+		  - {title}     (string) Border title
+		  - {position}  ("mouse"|"center") Placement
+		  - {enter}     (boolean) Focus the window
+		  - {footer}    (table[]) Chunk list for the bottom border,
+		    typically from |display_utils.build_footer_chunks()|
+
+					  *display_utils.build_footer_chunks()*
+					  *md-render-float-footer*
+display_utils.build_footer_chunks({info}, {width}) ~
+	Build the `{text, hl_group}` chunk list for a float's status footer.
+
+	Status info goes on the border footer rather than a statusline
+	because floating windows only draw a statusline when 'laststatus' is
+	1 or 2.  With 'laststatus' = 3 — what lualine's `globalstatus`
+	option sets — a float's window-local 'statusline' is used for the
+	global bar at the bottom of the screen instead, so the info would
+	not only be invisible, it would overwrite your statusline.  The
+	footer is always drawn and costs no content row.
+
+	The layout is `<name>  <line>/<total>  <bar>`.  The bar is ten cells
+	wide and made of box-drawing pieces — `━` for the part scrolled
+	past, `─` for the rest, `╾` for a half-filled cell.  The light half
+	is the glyph the border itself is made of, so the unfilled part
+	reads as a continuation of the border rather than as a widget.
+
+	The line number is right-aligned to the width of {total} so the
+	footer keeps a fixed width as you scroll.  When it doesn't fit
+	{width}, the bar shrinks to a minimum of four cells, then segments
+	are dropped from the right (bar, then position, then name).  Widths
+	are measured in display cells, so CJK file names are handled
+	correctly.
+
+	Parameters: ~
+	  {info}   (table) Segments to show:
+		   - {name}   (string|nil) File name
+		   - {line}   (integer|nil) Current line (clamped to {total})
+		   - {total}  (integer|nil) Total lines
+	  {width}  (integer) Inner width of the float
+
+	Return: ~
+	  (table[]) Chunk list; empty when nothing fits.
+
+					     *display_utils.set_float_footer()*
+display_utils.set_float_footer({win}, {chunks}, {pos}) ~
+	Apply a footer built by |display_utils.build_footer_chunks()| to a
+	floating window.  {pos} defaults to `"right"`.  A no-op for dead or
+	non-floating windows, so callers can share code with the tab, split,
+	and pager presentations.
+
 					   *display_utils.setup_float_keymaps()*
 display_utils.setup_float_keymaps({buf}, {ns}, {win}, {content}, ...) ~
 	Set up interactive keymaps (link clicking, fold toggling, etc.) in a
@@ -858,6 +917,19 @@ IMAGE ~
 
   *MdRenderImagePlaceholder*
                         Placeholder shown while images are loading
+
+FLOAT FOOTER ~
+
+  *MdRenderFooter*      Status info on the floating preview's bottom
+                        border (links to `FloatFooter`)
+  *MdRenderFooterName*  The file name segment of that footer
+                        (links to `FloatTitle`)
+  *MdRenderFooterBar*   Filled part of the progress bar
+                        (links to `FloatTitle`)
+							*MdRenderFooterBarEmpty*
+                        Unfilled part of the progress bar.  Links to
+                        `FloatBorder` so it blends into the border it
+                        is drawn on.
 
 SPLIT MODE ~
 

--- a/lua/md-render/display_utils.lua
+++ b/lua/md-render/display_utils.lua
@@ -218,11 +218,141 @@ function M.apply_content_to_buffer(buf, ns, content, opts)
   M.apply_treesitter_highlights(buf, ns, content)
 end
 
+--- Separator placed between footer segments.  Two spaces rather than a
+--- punctuation glyph: East Asian ambiguous-width characters (·, │, ...) are
+--- rendered at different widths depending on the terminal, which would make
+--- the fit calculation in `build_footer_chunks` unreliable.
+local FOOTER_SEP = "  "
+
+--- Progress bar drawn from box-drawing pieces: a heavy line for the part
+--- already scrolled past, a light line for the rest.  The light half is the
+--- same glyph the "rounded" border is made of, so the unfilled part reads as
+--- a continuation of the bottom border rather than as a separate widget, and
+--- `BAR_HALF` (heavy left, light right) keeps the line unbroken where the two
+--- meet — which also buys half-cell resolution.
+local BAR_FULL = "━"
+local BAR_HALF = "╾"
+local BAR_EMPTY = "─"
+local BAR_CELLS = 10
+--- Narrowest bar still worth drawing; below this the bar is dropped instead.
+local BAR_MIN_CELLS = 4
+
+--- Render `ratio` (0.0-1.0) as a `cells`-wide bar.
+---@param ratio number
+---@param cells integer
+---@return table[] chunks
+local function progress_bar(ratio, cells)
+  local halves = math.max(0, math.min(math.floor(ratio * cells * 2 + 0.5), cells * 2))
+  local full = math.floor(halves / 2)
+  local half = halves % 2
+  local filled = string.rep(BAR_FULL, full) .. (half == 1 and BAR_HALF or "")
+  local empty = string.rep(BAR_EMPTY, cells - full - half)
+
+  local chunks = {}
+  if filled ~= "" then table.insert(chunks, { filled, "MdRenderFooterBar" }) end
+  if empty ~= "" then table.insert(chunks, { empty, "MdRenderFooterBarEmpty" }) end
+  return chunks
+end
+
+--- Build the chunk list for a floating window's footer.
+---
+--- Floats can't rely on a statusline: Neovim only draws one inside a float
+--- when 'laststatus' is 1 or 2, and with 'laststatus' = 3 (what lualine's
+--- `globalstatus` sets) a float's window-local 'statusline' is used for the
+--- global bar at the bottom of the screen instead — so the info would not
+--- only be invisible, it would overwrite the user's statusline.  The border
+--- footer is drawn unconditionally and costs no content row, so status info
+--- goes there.
+---
+--- The layout is `<name>  <line>/<total>  <bar>`.  When it doesn't fit
+--- `width` the bar shrinks first, then segments are dropped from the right
+--- (bar, then position, then name).
+---@param info { name?: string, line?: integer, total?: integer }
+---@param width integer inner width of the float
+---@return table[] chunks  {text, hl_group} pairs for `footer`
+function M.build_footer_chunks(info, width)
+  local name = (info.name and info.name ~= "") and info.name or nil
+  local line, total
+  if info.line and info.total and info.total > 0 then
+    total = info.total
+    line = math.max(1, math.min(info.line, total))
+  end
+
+  --- Segments, each a chunk list of its own (the bar needs two chunks).
+  ---@param bar_cells integer  0 omits the bar
+  ---@param drop integer  how many trailing segments to leave out
+  local function segments_for(bar_cells, drop)
+    local segments = {}
+    if name then table.insert(segments, { { name, "MdRenderFooterName" } }) end
+    if line then
+      -- Right-align the line number to the width of `total`.  Unpadded, the
+      -- footer would grow as the cursor crosses a power of ten, shifting the
+      -- file name and resizing the bar while you scroll.
+      local position = string.format("%" .. #tostring(total) .. "d/%d", line, total)
+      table.insert(segments, { { position, "MdRenderFooter" } })
+      if bar_cells > 0 then table.insert(segments, progress_bar(line / total, bar_cells)) end
+    end
+    for _ = 1, drop do
+      table.remove(segments)
+    end
+    return segments
+  end
+
+  local bar_cells = BAR_CELLS
+  local drop = 0
+  while true do
+    local segments = segments_for(bar_cells, drop)
+    if #segments == 0 then return {} end
+
+    local chunks = { { " ", "MdRenderFooter" } }
+    -- One padding space on each side of the text.
+    local text_width = 2
+    for i, segment in ipairs(segments) do
+      if i > 1 then
+        table.insert(chunks, { FOOTER_SEP, "MdRenderFooter" })
+        text_width = text_width + vim.api.nvim_strwidth(FOOTER_SEP)
+      end
+      for _, chunk in ipairs(segment) do
+        table.insert(chunks, chunk)
+        text_width = text_width + vim.api.nvim_strwidth(chunk[1])
+      end
+    end
+    if text_width <= width then
+      table.insert(chunks, { " ", "MdRenderFooter" })
+      return chunks
+    end
+
+    if bar_cells > BAR_MIN_CELLS then
+      bar_cells = bar_cells - 1
+    elseif bar_cells > 0 then
+      bar_cells = 0
+    else
+      drop = drop + 1
+    end
+  end
+end
+
+--- Apply a footer to a floating window.  No-op for dead or non-floating
+--- windows, so callers can share code with the tab/split presentations.
+---@param win integer
+---@param chunks table[] chunk list from |build_footer_chunks|
+---@param pos? "left"|"center"|"right" defaults to "right"
+function M.set_float_footer(win, chunks, pos)
+  if not win or not vim.api.nvim_win_is_valid(win) then return end
+  local config = vim.api.nvim_win_get_config(win)
+  if config.relative == "" then return end
+  -- Partial configs are merged for floats, so size/position/title survive.
+  pcall(vim.api.nvim_win_set_config, win, {
+    footer = #chunks > 0 and chunks or "",
+    footer_pos = #chunks > 0 and (pos or "right") or nil,
+  })
+end
+
 --- Calculate window size and position, open the floating window
 ---@param buf integer
 ---@param content MdRender.Content
 ---@param float_win MdRender.FloatWin
----@param opts? { title?: string, position?: "mouse"|"center", enter?: boolean }
+---@param opts? { title?: string, position?: "mouse"|"center", enter?: boolean, footer?: table[] }
 ---@return integer win
 function M.open_float_window(buf, content, float_win, opts)
   opts = opts or {}
@@ -263,13 +393,17 @@ function M.open_float_window(buf, content, float_win, opts)
     border = "rounded",
     title = title,
     title_pos = "center",
+    footer = opts.footer,
+    footer_pos = opts.footer and "right" or nil,
   })
 
   float_win:setup(win, { auto_close = not enter })
 
   vim.api.nvim_set_option_value("wrap", true, { win = win })
   vim.api.nvim_set_option_value("cursorline", true, { win = win })
-  vim.wo[win].statusline = " "
+  -- Deliberately no window-local 'statusline' here: see the comment on
+  -- `build_footer_chunks`.  With 'laststatus' = 3 it would blank out the
+  -- global statusline while the float is focused.
   vim.api.nvim_buf_set_option(buf, "modifiable", false)
   vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
 

--- a/lua/md-render/init.lua
+++ b/lua/md-render/init.lua
@@ -97,6 +97,13 @@ function M.setup_highlights()
   vim.api.nvim_set_hl(0, "MdRenderLinkObsidian", { link = "Special", default = true })
   -- MdRenderSplit shadow cursor (marks the unfocused side's matching line)
   vim.api.nvim_set_hl(0, "MdRenderShadowCursor", { link = "CursorLine", default = true })
+  -- Preview float footer (status info drawn on the bottom border).
+  -- The unfilled part of the progress bar follows FloatBorder so it blends
+  -- into the border it is drawn on.
+  vim.api.nvim_set_hl(0, "MdRenderFooter", { link = "FloatFooter", default = true })
+  vim.api.nvim_set_hl(0, "MdRenderFooterName", { link = "FloatTitle", default = true })
+  vim.api.nvim_set_hl(0, "MdRenderFooterBar", { link = "FloatTitle", default = true })
+  vim.api.nvim_set_hl(0, "MdRenderFooterBarEmpty", { link = "FloatBorder", default = true })
   M.setup_heading_highlights()
   M.setup_alert_highlights()
   M.setup_details_highlights()

--- a/lua/md-render/preview.lua
+++ b/lua/md-render/preview.lua
@@ -209,6 +209,7 @@ end
 ---@field image_state? MdRender.ImageState
 ---@field dirty boolean               -- true when source changed while render was hidden
 ---@field _debounce_timer? table      -- libuv timer handle for live-update debounce
+---@field _update_footer? fun()       -- redraws the float footer (set by install_footer)
 local Session = {}
 Session.__index = Session
 
@@ -328,6 +329,9 @@ function Session:rebuild()
   end
   self.content = new_content
   self.dirty = false
+  -- Folding/expanding shifts the rendered line under the cursor without
+  -- firing CursorMoved, so refresh the footer explicitly.
+  if self._update_footer then self._update_footer() end
 end
 
 --- Lazily build sync points from `content.source_line_map`. A sync point
@@ -519,6 +523,56 @@ function Session:install_float_keymaps(close_handle, keymap_opts)
   })
 end
 
+--- Show status info (source file name, position in the source buffer) on the
+--- float's bottom border and keep it in sync with the cursor.
+---
+--- The footer is used rather than a statusline because floating windows only
+--- draw one when 'laststatus' is 1 or 2; see
+--- |display_utils.build_footer_chunks()| for the details.  It is a no-op for
+--- non-floating windows, so tab/split/pager presentations are unaffected.
+function Session:install_footer()
+  local win = self.win
+  if not win or not vim.api.nvim_win_is_valid(win) then return end
+  if vim.api.nvim_win_get_config(win).relative == "" then return end
+
+  local source_name = vim.api.nvim_buf_get_name(self.source_bufnr)
+  local name = source_name ~= "" and vim.fn.fnamemodify(source_name, ":t") or nil
+  local last_text = nil
+
+  local function update()
+    local w = self.win
+    if not w or not vim.api.nvim_win_is_valid(w) then return end
+    local rendered_line = vim.api.nvim_win_get_cursor(w)[1]
+    local chunks = display_utils.build_footer_chunks({
+      name = name,
+      -- Rendered lines don't line up with the source, so report the source
+      -- line the cursor maps back to — that's the number the user can act on.
+      line = self:rendered_to_source(rendered_line) or rendered_line,
+      total = #self.source_lines,
+    }, vim.api.nvim_win_get_config(w).width)
+
+    -- Most cursor movements land on the same source line (one source line
+    -- spans several rendered lines). Reconfiguring the window redraws it,
+    -- which can make inline images flicker, so only do it on a real change.
+    local text = ""
+    for _, chunk in ipairs(chunks) do
+      text = text .. chunk[1]
+    end
+    if text == last_text then return end
+    last_text = text
+
+    display_utils.set_float_footer(w, chunks)
+  end
+
+  self._update_footer = update
+  update()
+
+  vim.api.nvim_create_autocmd("CursorMoved", {
+    buffer = self.buf,
+    callback = update,
+  })
+end
+
 --- Track preview cursor and sync source cursor back when the window closes.
 --- Used by show / show_tab (not pager — pager replaces the buffer in place).
 function Session:install_cursor_sync()
@@ -602,6 +656,7 @@ MdPreview.show = function(opts)
   session:bind_window(win)
   session:scroll_to_source_line(source_cursor_line)
   session:install_cursor_sync()
+  session:install_footer()
   session:install_float_keymaps(float_win)
 end
 

--- a/tests/display_utils_test.lua
+++ b/tests/display_utils_test.lua
@@ -68,5 +68,87 @@ test("resolve_lang honors vim.treesitter.language.register", function()
   assert_eq(display_utils._resolve_lang "custom_md_lang", "markdown", "registered alias custom_md_lang -> markdown")
 end)
 
+-- ============================================================================
+-- build_footer_chunks: status info drawn on a float's bottom border
+-- ============================================================================
+
+--- Concatenate the text of a chunk list, ignoring highlight groups.
+local function footer_text(chunks)
+  local parts = {}
+  for _, chunk in ipairs(chunks) do
+    table.insert(parts, chunk[1])
+  end
+  return table.concat(parts)
+end
+
+test("build_footer_chunks renders name, position, and progress bar", function()
+  local chunks = display_utils.build_footer_chunks({ name = "README.md", line = 25, total = 100 }, 60)
+  assert_eq(footer_text(chunks), " README.md   25/100  ━━╾─────── ", "all segments present")
+  assert_eq(chunks[2][2], "MdRenderFooterName", "file name uses its own highlight group")
+  assert_eq(chunks[4][2], "MdRenderFooter", "position uses the plain footer group")
+  assert_eq(chunks[6][2], "MdRenderFooterBar", "filled part of the bar")
+  assert_eq(chunks[7][2], "MdRenderFooterBarEmpty", "unfilled part blends into the border")
+end)
+
+test("build_footer_chunks fills the bar in half-cell steps", function()
+  local function bar(line, total)
+    return footer_text(display_utils.build_footer_chunks({ line = line, total = total }, 60))
+  end
+  assert_eq(bar(1, 100), "   1/100  ────────── ", "1% rounds down to an empty bar")
+  assert_eq(bar(5, 100), "   5/100  ╾───────── ", "5% is one half cell")
+  assert_eq(bar(50, 100), "  50/100  ━━━━━───── ", "half way")
+  assert_eq(bar(100, 100), " 100/100  ━━━━━━━━━━ ", "end of file fills the bar")
+  assert_eq(bar(1, 1), " 1/1  ━━━━━━━━━━ ", "single-line file is complete at line 1")
+end)
+
+test("build_footer_chunks keeps a fixed width as the line number grows", function()
+  local function width_of(line)
+    return vim.api.nvim_strwidth(footer_text(display_utils.build_footer_chunks({ line = line, total = 120 }, 60)))
+  end
+  assert_eq(width_of(1), width_of(9), "1 and 9 are the same width")
+  assert_eq(width_of(9), width_of(10), "crossing ten does not resize the footer")
+  assert_eq(width_of(99), width_of(120), "crossing a hundred does not resize the footer")
+end)
+
+test("build_footer_chunks omits missing info", function()
+  assert_eq(footer_text(display_utils.build_footer_chunks({ name = "a.md" }, 40)), " a.md ", "name only")
+  assert_eq(
+    footer_text(display_utils.build_footer_chunks({ line = 1, total = 4 }, 40)),
+    " 1/4  ━━╾─────── ",
+    "position only"
+  )
+  assert_eq(#display_utils.build_footer_chunks({}, 40), 0, "no info -> no chunks")
+  assert_eq(#display_utils.build_footer_chunks({ name = "" }, 40), 0, "empty name -> no chunks")
+  assert_eq(#display_utils.build_footer_chunks({ line = 3, total = 0 }, 40), 0, "empty buffer -> no chunks")
+end)
+
+test("build_footer_chunks shrinks the bar, then drops segments", function()
+  local info = { name = "README.md", line = 25, total = 100 }
+  local function fit(width)
+    return footer_text(display_utils.build_footer_chunks(info, width))
+  end
+  assert_eq(fit(32), " README.md   25/100  ━━╾─────── ", "exact fit")
+  assert_eq(fit(31), " README.md   25/100  ━━╾────── ", "bar shrinks")
+  assert_eq(fit(26), " README.md   25/100  ━─── ", "bar hits its floor at four cells")
+  assert_eq(fit(25), " README.md   25/100 ", "bar dropped next")
+  assert_eq(fit(19), " README.md ", "position dropped next")
+  assert_eq(#display_utils.build_footer_chunks(info, 10), 0, "nothing fits -> no chunks")
+end)
+
+test("build_footer_chunks measures display width, not bytes", function()
+  local chunks = display_utils.build_footer_chunks({ name = "設計メモ.md" }, 16)
+  assert_eq(footer_text(chunks), " 設計メモ.md ", "CJK name fits its display width")
+  assert_eq(
+    #display_utils.build_footer_chunks({ name = "設計メモ.md" }, 12),
+    0,
+    "same name does not fit a 12-cell float"
+  )
+end)
+
+test("build_footer_chunks clamps an out-of-range line", function()
+  local chunks = display_utils.build_footer_chunks({ line = 999, total = 40 }, 40)
+  assert_eq(footer_text(chunks), " 40/40  ━━━━━━━━━━ ", "line beyond total clamps to total")
+end)
+
 print(string.format("display_utils_test: %d passed, %d failed", pass_count, fail_count))
 if fail_count > 0 then os.exit(1) end


### PR DESCRIPTION
## What

フローティングプレビュー (`:MdRender float`) の下ボーダーにステータスフッタを追加します。表示するのは、ソースのファイル名・カーソルが対応するソースの行・罫線素片で描いたプログレスバーです。

```
╰──────────────────── README.md    1/403  ────────── ╯   先頭
╰──────────────────── README.md  200/403  ━━━━━───── ╯   中ほど
╰──────────────────── README.md  403/403  ━━━━━━━━━━ ╯   末尾
```

## Why

プレビューにはタイトル以外の情報が無く、どのファイルを見ているのか、どのあたりにいるのかが分かりませんでした。

ステータスラインは使えません。Neovim がフロート内にステータスラインを描画するのは `'laststatus'` が 1 か 2 のときだけで、3 (lualine の `globalstatus` が設定する値) のときはフロートのウィンドウローカルな `'statusline'` が画面下端のグローバルバーとして使われます。実機 (v0.13.0-dev) の画面ダンプで確認しました:

| `'laststatus'` | フロート内に描画されるか |
|---|---|
| 0 | されない |
| 1 / 2 | される (下ボーダーの 1 つ内側に 1 行増える) |
| 3 | されない。代わりに画面下端のグローバルバーがフロートの値で上書きされる |

`open_float_window` が初期コミットから設定していた `vim.wo[win].statusline = " "` は、このため `'laststatus'` = 3 の環境ではフロートに何も出さず、プレビューにフォーカスしている間ユーザのステータスラインを空白で塗り潰すだけでした。削除します。

ボーダーの footer なら無条件に描画され、本文の行も消費しません。lualine 側も refresh 対象から `win_gettype() == "popup"` を除外している (`lualine.lua` の `wins` フィルタ) ので、フロートのローカル設定と衝突しません。

## How

- `display_utils.build_footer_chunks(info, width)` — `<name>  <line>/<total>  <bar>` の chunk リストを組み立てる純粋関数。
- `display_utils.set_float_footer(win, chunks, pos)` — 部分 config の `nvim_win_set_config` で footer だけ差し替える (サイズ・位置・title は保持される)。非フローティング / 無効なウィンドウでは no-op なので、tab・split・pager の経路は素通りする。
- `Session:install_footer()` — `MdPreview.show` から呼び、`CursorMoved` で追従。折りたたみはカーソルを動かさないので `Session:rebuild` からも更新する。
- 行番号は `rendered_to_source` でソース側の行に戻した値。レンダリング後の行番号は元ファイルと対応せず、これはプレビューを閉じたときにカーソルが戻る行と一致する。

バーの設計:

- 通過済みが `━` (U+2501)、残りが `─` (U+2500)、境界のセルが `╾` (U+257E, heavy left and light right)。境界セルのおかげで線が途切れず、半セル分解能 (10 セルで 5% 刻み) が得られる。
- 細線側は `rounded` ボーダーと同じ字で、ハイライトも `FloatBorder` にリンクした `MdRenderFooterBarEmpty`。未達の部分はボーダーの続きにしか見えず、進捗の太線だけが浮かぶ。
- 行番号は `total` の桁数に右寄せ。パディングが無いと桁上がりのたびにフッタの幅が変わり、右寄せなのでファイル名が動き、バーの長さまで変わってしまう。
- 幅が足りないときは バー 10 → 4 セルまで縮小 → バーを落とす → 位置を落とす → ファイル名だけ → 何も出さない、の順で縮退する。幅は `nvim_strwidth` で測るので CJK のファイル名と `'ambiwidth'` = `double` にも追従する。
- footer の文字列が変わらないときは `nvim_win_set_config` を呼ばない。1 ソース行が複数のレンダリング行にまたがるためほとんどのカーソル移動では内容が変わらず、毎回叩くとインライン画像がチラつく。

ハイライトグループ (すべて `default = true`): `MdRenderFooter` (→ `FloatFooter`) / `MdRenderFooterName` (→ `FloatTitle`) / `MdRenderFooterBar` (→ `FloatTitle`) / `MdRenderFooterBarEmpty` (→ `FloatBorder`)。

## Test

- `tests/display_utils_test.lua` に `build_footer_chunks` のテストを 8 件追加 (半セル刻みの充填、桁上がりで幅が変わらないこと、縮退の順序、CJK ファイル名の幅、クランプ、情報欠落時)。`make test` 全 13 ファイル green、`stylua --check .` 通過。
- 実際の README (403 行) をプレビューして画面グリッドをダンプし、`'laststatus'` = 3 でグローバルバーが無傷なこと、先頭・中ほど・末尾でバーが正しく伸びることを確認。
- 幅 32 → 5 まで狭めながらフッタの縮退と `title` の保持を確認。`'ambiwidth'` = `double` でバーが自動的に縮んで収まることを確認。
- `:MdRender demo` は従来どおり footer 無し。tab / split / toggle / pager は非フローティングなので影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
