### PR TITLE
fix(image): drop the removed -vsync option so videos and GIFs still render

### DIFF
--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -1220,6 +1220,21 @@ local function build_frame_count_cmd(tool, path)
   end
 end
 
+--- Report a frame-extraction failure once per distinct error.
+---
+--- Both extraction paths otherwise just drop the frames and return nil, which
+--- leaves the placeholder reading "Loading video..." with nothing to explain
+--- why. A removed FFmpeg option looked exactly like a slow download.
+---@param tool string
+---@param result vim.SystemCompleted
+local function warn_extract_failed(tool, result)
+  local detail = (result.stderr or ""):match "[^\r\n]+$" or ("exit code " .. tostring(result.code))
+  vim.notify_once(
+    string.format("md-render: %s could not extract video/animation frames: %s", tool, detail),
+    vim.log.levels.WARN
+  )
+end
+
 --- Build a command to extract frames from an animated GIF.
 ---@param tool string  "ffmpeg" or "magick"
 ---@param path string  GIF file path
@@ -1232,6 +1247,14 @@ local function build_frame_extract_cmd(tool, path, cache_dir, total_frames)
     -- Convert to display frame rate (5 fps matches the 200 ms animation timer)
     table.insert(vf_parts, "fps=5")
     table.insert(vf_parts, "scale='min(400,iw)':'min(400,ih)':force_original_aspect_ratio=decrease")
+    -- No `-vsync` / `-fps_mode`: the `fps` filter above already resamples to a
+    -- constant rate, so the mode is redundant, and neither spelling works on
+    -- every FFmpeg. `-vsync` was deprecated in 2022 (5.1 added `-fps_mode` as
+    -- its replacement) and finally removed in 9.0; `-fps_mode` in turn does
+    -- not exist before 5.1. Passing an option the local FFmpeg does not know
+    -- makes it exit before decoding anything ("Unrecognized option 'vsync'"),
+    -- which surfaced as videos and animated GIFs stuck on "Loading video..."
+    -- forever. Omitting both is the only spelling valid across all versions.
     return {
       "ffmpeg",
       "-y",
@@ -1241,8 +1264,6 @@ local function build_frame_extract_cmd(tool, path, cache_dir, total_frames)
       table.concat(vf_parts, ","),
       "-frames:v",
       tostring(MAX_ANIM_FRAMES),
-      "-vsync",
-      "vfr",
       cache_dir .. "/frame_%04d.png",
     }
   else
@@ -1264,6 +1285,8 @@ local function build_frame_extract_cmd(tool, path, cache_dir, total_frames)
     return cmd
   end
 end
+
+M._build_frame_extract_cmd = build_frame_extract_cmd -- exposed for testing
 
 -- Forward declarations: these helpers are defined further down but are already
 -- referenced by M.transmit_animated below. Without this, the calls would resolve
@@ -1304,6 +1327,7 @@ function M.transmit_animated(path)
     local result = vim.system(cmd, { text = true, timeout = 30000 }):wait()
 
     if result.code ~= 0 then
+      warn_extract_failed(anim_tool, result)
       vim.fn.delete(cache_dir, "rf")
       return nil
     end
@@ -1474,6 +1498,7 @@ function M.transmit_animated_async(path, callback)
       vim.system(cmd, { text = true, timeout = 30000 }, function(result)
         vim.schedule(function()
           if result.code ~= 0 then
+            warn_extract_failed(anim_tool, result)
             vim.fn.delete(cache_dir, "rf")
             callback(nil)
             return

--- a/tests/image_test.lua
+++ b/tests/image_test.lua
@@ -840,6 +840,27 @@ if has_convert_tool() then
 end
 
 -- ============================================================================
+-- Frame extraction command
+-- ============================================================================
+
+test("frame extract cmd: no -vsync / -fps_mode", function()
+  -- `-vsync` was removed in FFmpeg 9.0 and `-fps_mode` only exists from 5.1,
+  -- so neither spelling works across the versions users have. Passing an
+  -- unknown one makes FFmpeg exit before decoding anything, which showed up as
+  -- videos and animated GIFs stuck on "Loading video..." forever. The `fps`
+  -- filter already resamples to a constant rate, so no mode option is needed.
+  local cmd = image._build_frame_extract_cmd("ffmpeg", "/tmp/in.mp4", "/tmp/out", 100)
+  for _, arg in ipairs(cmd) do
+    assert_true(arg ~= "-vsync", "extract cmd must not pass -vsync")
+    assert_true(arg ~= "-fps_mode", "extract cmd must not pass -fps_mode")
+  end
+  assert_eq(cmd[1], "ffmpeg", "extract cmd runs ffmpeg")
+  assert_eq(cmd[#cmd], "/tmp/out/frame_%04d.png", "extract cmd writes numbered frames")
+  local joined = table.concat(cmd, " ")
+  assert_match(joined, "fps=5", "extract cmd resamples with the fps filter")
+end)
+
+-- ============================================================================
 -- Summary
 -- ============================================================================
 


### PR DESCRIPTION
## Problem

Every video and every animated GIF silently stopped rendering, leaving the placeholder on `Loading video...` forever.

FFmpeg 9.0 removed `-vsync`, which the frame-extraction command passes. An unknown option makes FFmpeg exit *before it decodes anything*:

```
Unrecognized option 'vsync'.
Error splitting the argument list: Option not found
```

Both extraction paths treat a non-zero exit as "no frames": they delete the cache directory and return `nil`, with no message. So a removed CLI option was indistinguishable from a slow download.

## Why now

`-vsync` was deprecated on 2022-06-11, and 5.1 added `-fps_mode` to replace it. The removal landed in [`927ffd093`](https://github.com/FFmpeg/FFmpeg/commit/927ffd093) (2026-06-23) and first shipped in **FFmpeg 9.0** (2026-08-03). 8.0 (2025-08-21) still accepted it, so this breaks the moment a user upgrades to 9.

Verified by reading the option table in `fftools/ffmpeg_opt.c` at each release tag:

| tag | `-vsync` | `-fps_mode` |
|---|---|---|
| `n5.0` | registered | — |
| `n5.1` … `n8.0` | registered | registered |
| `n9.0` | **removed** | registered |

## Fix

Drop the option rather than switch to `-fps_mode`. The replacement does not exist before 5.1, so swapping spellings only trades one version-specific failure for another. It is redundant here anyway — the `fps=5` filter already resamples to a constant rate — so omitting it is valid on every version.

Also warn once (`vim.notify_once`) when extraction fails, with the tail of the tool's stderr. The silent `nil` is what let this go unnoticed.

## Verification

Against ffmpeg 9.0.1, with the frame cache cleared:

| asset | with `-vsync` | after |
|---|---|---|
| `assets/demo/test_animated.gif` | `id=nil anim=false` | `id=102 anim=true frames=8` |
| `assets/demo/test.mp4` | `id=nil anim=false` | `id=110 anim=true frames=50` |
| `assets/demo/test.png` (static) | `id=101` | `id=101` |

Static images were never affected — they go through a different command. Confirmed visually in Kitty that `README.ja.md`'s inline video plays again.

Frame counts are identical with and without the option (115 / 115 on the showcase video), so nothing about the output changes.

## Tests

`tests/image_test.lua` gains a regression test asserting the extract command passes neither `-vsync` nor `-fps_mode`. Re-introducing the option makes it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)