### PR TITLE
test(media): run the real media tools against an FFmpeg 6/7/8/9 matrix

### DIFF
--- a/.github/workflows/media.yml
+++ b/.github/workflows/media.yml
@@ -1,0 +1,98 @@
+name: Media tools
+
+# The unit tests check the bytes md-render emits. This job checks that the
+# commands it runs still work, against several FFmpeg majors.
+#
+# It exists because of a silent breakage: FFmpeg 9 removed `-vsync`, frame
+# extraction started failing for every video and animated GIF, and nothing
+# caught it — the emitted escape sequences were still correct, and no commit
+# had touched the code. Hence the schedule: the failure mode is the toolchain
+# moving, not the repo changing.
+#
+# The matrix must span majors rather than track one version. Ubuntu 24.04 still
+# ships FFmpeg 6.1, so a job that just runs `apt-get install ffmpeg` would have
+# stayed green through the entire incident.
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Mondays 03:00 UTC. Catches toolchain drift with no commit involved.
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+jobs:
+  ffmpeg-matrix:
+    name: ffmpeg ${{ matrix.ffmpeg.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ffmpeg:
+          # 6.x and 7.x come from a pinned old autobuild: BtbN drops branches
+          # from its rolling `latest` release once they go EOL, but release
+          # assets themselves persist, so these URLs stay valid.
+          - name: "6.1"
+            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-09-30-15-36/ffmpeg-n6.1.2-8-gf00f71f590-linux64-gpl-6.1.tar.xz
+          - name: "7.1"
+            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-09-30-15-36/ffmpeg-n7.1-linux64-gpl-7.1.tar.xz
+          # 8.x, 9.x and master are rolling: the assets are rebuilt in place,
+          # so the scheduled run picks up new point releases automatically.
+          # This is the part that actually detects drift.
+          - name: "8.1"
+            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-linux64-gpl-8.1.tar.xz
+          - name: "9.0"
+            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n9.0-latest-linux64-gpl-9.0.tar.xz
+          - name: master
+            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Install FFmpeg ${{ matrix.ffmpeg.name }}
+        run: |
+          set -euxo pipefail
+          curl -fsSL -o /tmp/ffmpeg.tar.xz "${{ matrix.ffmpeg.url }}"
+          mkdir -p /tmp/ffmpeg && tar -xJf /tmp/ffmpeg.tar.xz -C /tmp/ffmpeg --strip-components=1
+          echo "/tmp/ffmpeg/bin" >> "$GITHUB_PATH"
+
+      - name: Install ImageMagick
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends imagemagick
+
+      # MD_RENDER_REQUIRE_MEDIA_TOOLS turns "tool missing, skipping" into a
+      # failure. Without it a broken install step would look like a pass.
+      - name: Run media tests
+        env:
+          MD_RENDER_REQUIRE_MEDIA_TOOLS: "1"
+        run: nvim --headless -u NONE --noplugin -l tests/media_test.lua
+
+  # The scheduled run is only meaningful if someone hears about it. A failing
+  # cron job on a repo nobody is watching is the same as no test at all.
+  notify:
+    name: Open an issue on scheduled failure
+    needs: ffmpeg-matrix
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Scheduled media-tool test failed";
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data: open } = await github.rest.issues.listForRepo({
+              ...context.repo, state: "open", labels: "toolchain",
+            });
+            const existing = open.find(i => i.title === title);
+            const body = `The weekly FFmpeg matrix failed. An external tool most likely changed under us.\n\n${url}`;
+            if (existing) {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({ ...context.repo, title, body, labels: ["toolchain"] });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ doc/tags*
 # Visual test screenshots (reference images are tracked separately)
 tests/screenshots/
 !tests/screenshots/reference/
+
+# Python bytecode from the visual test helper
+__pycache__/

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,10 +2,13 @@
 
 ## Overview
 
-| Layer | What | Where | How |
-|-------|------|-------|-----|
-| 1. Unit tests | Escape sequence verification | CI (push/PR) | `nvim --headless -l tests/image_test.lua` |
-| 2. Visual regression | Screenshot comparison across terminals | Local only | `./tests/run_visual_test.sh` |
+| Layer | What | Catches | Where | How |
+|-------|------|---------|-------|-----|
+| 1. Unit tests | The bytes md-render *emits* | Protocol regressions | CI (push/PR) | `make test` |
+| 2. Media tools | The commands md-render *runs* | An external tool changing under us | CI (push/PR **and weekly**) | `nvim --headless -u NONE --noplugin -l tests/media_test.lua` |
+| 3. Visual regression | What the terminal actually *draws* | Clipped glyphs, images that never paint | Local only | `./tests/run_visual_test.sh` |
+
+Layer 2 exists because of a silent breakage: FFmpeg 9 removed `-vsync`, frame extraction failed for every video and animated GIF, and nothing noticed — the emitted escape sequences were still correct and no commit had touched the code. The failure mode was the toolchain moving, so the test runs on a schedule, not just on push.
 
 ## Running all CI tests locally
 
@@ -28,7 +31,24 @@ Mock-based tests that verify Kitty Graphics Protocol escape sequences without re
 
 Tests monkey-patch `vim.api.nvim_ui_send` to capture the bytes the image module would emit (mirrors Neovim's own `test/functional/ui/img_spec.lua`). The image module also exposes `_set_kitty_supported` and `_reset_image_id` for state control.
 
-## Layer 2: Visual regression tests
+## Layer 2: Media tool tests
+
+`media_test.lua` runs the real external tools (ffmpeg, ffprobe, ImageMagick, sips) against the bundled assets in `assets/demo/` and asserts that frames and PNGs actually come out.
+
+Two details make it meaningful rather than decorative:
+
+- **It forces a cache miss.** Both the frame cache and the converted-PNG cache are keyed on a hash of the source path, so testing a bundled path directly would hit a cache from an earlier run and never invoke the tool. The test copies each asset to a unique temporary path first.
+- **It refuses to pass by not testing.** A missing tool is reported as `skip` so contributors without ffmpeg can still run `make test`, but CI sets `MD_RENDER_REQUIRE_MEDIA_TOOLS=1`, which turns every skip into a failure.
+
+The test prints the version of each tool it found; when the matrix goes red the first useful question is which toolchain it went red on.
+
+### FFmpeg matrix
+
+`.github/workflows/media.yml` runs the suite against FFmpeg 6.1, 7.1, 8.1, 9.0 and master, plus a weekly `schedule`.
+
+Spanning majors is the point. Ubuntu 24.04 still ships FFmpeg 6.1, so a job that ran `apt-get install ffmpeg` would have stayed green through the entire `-vsync` incident. The 8.x/9.x/master entries point at BtbN's rolling `latest` release, so the scheduled run picks up new point releases and reports drift; 6.1 and 7.1 come from a pinned older autobuild, because BtbN drops EOL branches from `latest` while keeping the release assets reachable.
+
+## Layer 3: Visual regression tests
 
 Screenshot-based tests that launch real terminal emulators and compare rendered output against reference images.
 
@@ -37,7 +57,10 @@ Screenshot-based tests that launch real terminal emulators and compare rendered 
 - macOS (uses `screencapture` and Quartz for window capture)
 - At least one of: WezTerm, Kitty, Ghostty
 - ImageMagick (`magick`) for SSIM comparison
-- Screen Recording permission granted to the terminal running the script
+- **PyObjC**: `pip install pyobjc-framework-Quartz`. Without it the capture cannot be scoped to one window and the script aborts.
+- **Screen Recording permission** for whatever runs the script (System Settings > Privacy & Security > Screen Recording)
+
+This layer is a deliberate gate, not something to run on every save: it opens GUI windows and takes over the screen while it runs, and a whole-window SSIM is sensitive to font, colorscheme and OS updates.
 
 ### Usage
 
@@ -87,7 +110,9 @@ tests/screenshots/
 
 - The test Markdown (`tests/fixtures/visual_test.md`) avoids using the same image file in multiple places to prevent WezTerm image ID conflicts.
 - Animated GIF tests are included -- the animation timer affects image placement timing on WezTerm.
-- `tests/capture_window.py` uses the macOS Quartz API to find window IDs by PID.
+- `tests/capture_window.py` finds the window by **title**, not PID: terminals re-exec, so the PID the shell holds often does not own the window. `tests/visual_test_init.lua` sets the title from Neovim via `'title'` (OSC 2), which every supported terminal honours — unlike the per-terminal command line flags, which differ and do not all set the name macOS reports.
+- The script **never falls back to a full-screen capture**. An earlier version did, and with PyObjC missing it silently photographed the whole desktop and wrote it out as a reference image.
+- Much of what a screenshot is reached for can be answered without pixels: `kitty @ get-text` reports the actual cell grid, which is enough to check things like whether a heading occupies a two-row multicell group. Reserve this layer for questions that genuinely need pixels.
 
 ## Adding new tests
 
@@ -116,4 +141,4 @@ print(string.format("\n%d passed, %d failed", pass_count, fail_count))
 if fail_count > 0 then os.exit(1) end
 ```
 
-Then add it to `.github/workflows/test.yml`.
+`make test` globs `tests/*_test.lua`, so a new file is picked up automatically — no workflow change needed.

--- a/tests/capture_window.py
+++ b/tests/capture_window.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python3
 """
-Capture a screenshot of a window owned by the given PID.
+Capture a screenshot of a single window.
 
-Usage: capture_window.py <pid> <output.png>
+Usage: capture_window.py <pid|--title SUBSTRING> <output.png>
 
-Uses macOS Quartz (CoreGraphics) to find the window and screencapture
-to take the screenshot. Falls back to full-screen capture if the window
-cannot be found.
+Prefer --title. Terminals re-exec themselves, so the PID the shell knows is
+often not the PID that owns the window: launching kitty and matching on `$!`
+finds nothing. Matching the window title is reliable as long as the terminal
+was launched with a distinctive one (`kitty --title MDRENDER_PROBE ...`).
+
+This never falls back to a full-screen capture. An earlier version did, and
+when PyObjC was missing it silently photographed the developer's entire
+desktop and wrote it out as if it were a test artifact — wrong as a reference
+image, and a privacy problem. A capture that cannot be scoped to one window is
+a failure.
+
+Requires:
+  - PyObjC (`pip install pyobjc-framework-Quartz`) to resolve window ids
+  - Screen Recording permission for whatever runs this (System Settings >
+    Privacy & Security > Screen Recording). Without it `screencapture`
+    fails or returns an empty image.
 """
 
 import subprocess
@@ -14,76 +27,77 @@ import sys
 import time
 
 
-def find_window_id(target_pid):
-    """Find the CGWindowID for the largest window owned by target_pid."""
+def load_quartz():
     try:
-        import Quartz
+        import Quartz  # noqa: F401
+
+        return Quartz
     except ImportError:
-        return None
+        sys.exit(
+            "error: PyObjC is required to capture a single window.\n"
+            "  pip install pyobjc-framework-Quartz\n"
+            "Refusing to fall back to a full-screen capture."
+        )
 
-    target_pid = int(target_pid)
 
-    # CGWindowListCopyWindowInfo returns all on-screen windows
-    window_list = Quartz.CGWindowListCopyWindowInfo(
+def on_screen_windows(Quartz):
+    return Quartz.CGWindowListCopyWindowInfo(
         Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
         Quartz.kCGNullWindowID,
     )
 
-    best_id = None
-    best_area = 0
 
-    for win in window_list:
-        pid = win.get(Quartz.kCGWindowOwnerPID, -1)
-        if pid != target_pid:
-            continue
+def area(win, Quartz):
+    bounds = win.get(Quartz.kCGWindowBounds, {})
+    return bounds.get("Width", 0) * bounds.get("Height", 0)
 
-        # Pick the largest window (by area) owned by this PID
-        bounds = win.get(Quartz.kCGWindowBounds, {})
-        w = bounds.get("Width", 0)
-        h = bounds.get("Height", 0)
-        area = w * h
 
-        if area > best_area:
-            best_area = area
-            best_id = win.get(Quartz.kCGWindowNumber)
+def find_by_pid(Quartz, target_pid):
+    """Largest on-screen window owned by target_pid."""
+    matches = [w for w in on_screen_windows(Quartz) if w.get(Quartz.kCGWindowOwnerPID, -1) == target_pid]
+    return max(matches, key=lambda w: area(w, Quartz), default=None)
 
-    return best_id
+
+def find_by_title(Quartz, needle):
+    """Largest on-screen window whose title contains needle."""
+    matches = [w for w in on_screen_windows(Quartz) if needle in (w.get(Quartz.kCGWindowName) or "")]
+    return max(matches, key=lambda w: area(w, Quartz), default=None)
 
 
 def main():
-    if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} <pid> <output.png>", file=sys.stderr)
-        sys.exit(2)
+    argv = sys.argv[1:]
+    if len(argv) == 3 and argv[0] == "--title":
+        finder, describe, output = (lambda q: find_by_title(q, argv[1])), f"title containing {argv[1]!r}", argv[2]
+    elif len(argv) == 2:
+        pid = int(argv[0])
+        finder, describe, output = (lambda q: find_by_pid(q, pid)), f"pid {pid}", argv[1]
+    else:
+        sys.exit(f"Usage: {sys.argv[0]} <pid|--title SUBSTRING> <output.png>")
 
-    pid = int(sys.argv[1])
-    output = sys.argv[2]
+    Quartz = load_quartz()
 
-    # Retry a few times in case the window hasn't appeared yet
-    window_id = None
-    for attempt in range(10):
-        window_id = find_window_id(pid)
-        if window_id is not None:
+    win = None
+    for _ in range(10):  # the window may not be mapped yet
+        win = finder(Quartz)
+        if win is not None:
             break
         time.sleep(0.5)
 
-    if window_id is not None:
-        # screencapture -l <CGWindowID> captures just that window
-        result = subprocess.run(
-            ["screencapture", "-l", str(window_id), "-o", "-x", output],
-            capture_output=True,
-        )
-        if result.returncode == 0:
-            print(f"Captured window {window_id} (pid {pid}) -> {output}")
-            return
-        else:
-            print(
-                f"screencapture failed for window {window_id}: {result.stderr.decode()}",
-                file=sys.stderr,
-            )
+    if win is None:
+        sys.exit(f"error: no on-screen window matching {describe}")
 
-    # Fallback: full screen
-    print(f"Warning: could not find window for PID {pid}, capturing full screen", file=sys.stderr)
-    subprocess.run(["screencapture", "-x", output])
+    window_id = win.get(Quartz.kCGWindowNumber)
+    result = subprocess.run(
+        ["screencapture", "-l", str(window_id), "-o", "-x", output],
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        sys.exit(
+            f"error: screencapture failed for window {window_id}: {result.stderr.decode().strip()}\n"
+            "Is Screen Recording permission granted?"
+        )
+
+    print(f"Captured window {window_id} ({describe}) -> {output}")
 
 
 if __name__ == "__main__":

--- a/tests/media_test.lua
+++ b/tests/media_test.lua
@@ -1,0 +1,219 @@
+-- Integration tests for the external media tools (ffmpeg / ImageMagick / sips).
+--
+-- Everything else in tests/ checks the bytes md-render *emits*. This file
+-- checks that the commands it *runs* still work, by actually invoking them on
+-- the bundled demo assets. That is the layer that catches a toolchain moving
+-- underneath us: FFmpeg 9 removed `-vsync`, extraction started failing for
+-- every video and animated GIF, and no unit test noticed because the escape
+-- sequences md-render would have emitted were still correct.
+--
+-- Run: nvim --headless -u NONE --noplugin -l tests/media_test.lua
+--
+-- Missing tools are reported as SKIP so a contributor without ffmpeg can still
+-- run `make test`. Set MD_RENDER_REQUIRE_MEDIA_TOOLS=1 (as CI does) to turn a
+-- skip into a failure, so the matrix can never go green by not testing.
+
+package.path = vim.fn.getcwd() .. "/lua/?.lua;" .. vim.fn.getcwd() .. "/lua/?/init.lua;" .. package.path
+
+local image = require "md-render.image"
+
+local pass_count = 0
+local fail_count = 0
+local skip_count = 0
+
+local REQUIRE_TOOLS = vim.env.MD_RENDER_REQUIRE_MEDIA_TOOLS == "1"
+
+local function pass(msg)
+  pass_count = pass_count + 1
+  print("  ok   " .. msg)
+end
+
+local function fail(msg, detail)
+  fail_count = fail_count + 1
+  print("  FAIL " .. msg)
+  if detail then print("       " .. detail) end
+end
+
+local function skip(msg, why)
+  if REQUIRE_TOOLS then
+    fail(msg, "required tool missing: " .. why .. " (MD_RENDER_REQUIRE_MEDIA_TOOLS=1)")
+    return
+  end
+  skip_count = skip_count + 1
+  print("  skip " .. msg .. " (" .. why .. ")")
+end
+
+local function have(exe)
+  return vim.fn.executable(exe) == 1
+end
+
+-- ---------------------------------------------------------------------------
+-- Environment report
+--
+-- Printed unconditionally: when the matrix goes red, the first thing worth
+-- knowing is which toolchain it went red on.
+-- ---------------------------------------------------------------------------
+
+local function tool_version(exe, args)
+  if not have(exe) then return "(not installed)" end
+  local r = vim.system(vim.list_extend({ exe }, args), { text = true }):wait()
+  local out = (r.stdout or "") .. (r.stderr or "")
+  return vim.trim((out:gmatch "[^\r\n]+")() or "?")
+end
+
+print "media_test environment:"
+print("  ffmpeg   " .. tool_version("ffmpeg", { "-version" }))
+print("  ffprobe  " .. tool_version("ffprobe", { "-version" }))
+print("  magick   " .. tool_version("magick", { "-version" }))
+print("  sips     " .. (have "sips" and "present" or "(not installed)"))
+print ""
+
+-- ---------------------------------------------------------------------------
+-- Harness
+-- ---------------------------------------------------------------------------
+
+local root = vim.fn.getcwd()
+local tmp = vim.fn.tempname()
+vim.fn.mkdir(tmp, "p")
+
+--- Copy an asset to a fresh path so its cache key is unique to this run.
+---
+--- Both the frame cache and the converted-PNG cache are keyed on a hash of the
+--- source path, so testing the bundled path directly would hit a cache left by
+--- an earlier run and never invoke the tool at all — a green that proves
+--- nothing. A unique path guarantees a cache miss and a real invocation.
+---@param name string file under assets/demo/
+---@return string path
+local function fresh_copy(name)
+  local src = root .. "/assets/demo/" .. name
+  local dst = string.format("%s/%d_%s", tmp, pass_count + fail_count + skip_count, name)
+  local data = assert(io.open(src, "rb")):read "*a"
+  local out = assert(io.open(dst, "wb"))
+  out:write(data)
+  out:close()
+  return dst
+end
+
+--- Run an async transmit and wait for its callback.
+---@param fn fun(path: string, cb: fun(...))
+---@param path string
+---@return any
+local function await(fn, path)
+  local result, done = nil, false
+  fn(path, function(...)
+    result = { ... }
+    done = true
+  end)
+  -- Generous: a cold ffmpeg decode of the sample video takes ~1s locally, but
+  -- CI runners are slower and the frame transmit yields to the event loop.
+  vim.wait(120000, function()
+    return done
+  end, 50)
+  if not done then return nil, "timed out" end
+  return result[1]
+end
+
+-- md-render only talks to the terminal when it believes one is listening, and
+-- these tests run headless. Pretend, and swallow the writes.
+local real_ui_send = vim.api.nvim_ui_send
+vim.api.nvim_ui_send = function() end
+image._set_kitty_supported(true)
+
+-- ---------------------------------------------------------------------------
+-- Animated GIF and video frame extraction (ffmpeg / magick)
+-- ---------------------------------------------------------------------------
+
+--- @param label string
+--- @param asset string
+--- @param min_frames integer
+local function check_frames(label, asset, min_frames)
+  if not (have "ffmpeg" or have "magick") then
+    skip(label, "needs ffmpeg or magick")
+    return
+  end
+  local path = fresh_copy(asset)
+  local ids, err = await(image.transmit_animated_async, path)
+  if err then
+    fail(label, err)
+  elseif type(ids) ~= "table" or #ids < min_frames then
+    fail(label, string.format("expected >= %d frames, got %s", min_frames, ids and #ids or "nil"))
+  else
+    pass(string.format("%s -> %d frames", label, #ids))
+  end
+end
+
+check_frames("animated GIF extracts frames", "test_animated.gif", 2)
+check_frames("MP4 video extracts frames", "test.mp4", 2)
+
+-- ---------------------------------------------------------------------------
+-- Video probing (ffprobe)
+-- ---------------------------------------------------------------------------
+
+do
+  local label = "ffprobe reports video dimensions"
+  if not have "ffprobe" then
+    skip(label, "needs ffprobe")
+  else
+    local w, h = image.video_dimensions(root .. "/assets/demo/test.mp4")
+    if type(w) == "number" and type(h) == "number" and w > 0 and h > 0 then
+      pass(string.format("%s -> %dx%d", label, w, h))
+    else
+      fail(label, "got " .. vim.inspect { w, h })
+    end
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- Static conversion to PNG (sips / ffmpeg / magick)
+-- ---------------------------------------------------------------------------
+
+--- @param label string
+--- @param asset string
+local function check_convert(label, asset)
+  if not (have "sips" or have "ffmpeg" or have "magick") then
+    skip(label, "needs sips, ffmpeg or magick")
+    return
+  end
+  local png = image.ensure_png(fresh_copy(asset))
+  if type(png) ~= "string" or vim.fn.filereadable(png) ~= 1 then
+    fail(label, "no PNG produced (got " .. vim.inspect(png) .. ")")
+    return
+  end
+  local w, h = image.image_dimensions(png)
+  if not w or not h or w <= 0 or h <= 0 then
+    fail(label, "output is not a readable PNG: " .. png)
+  else
+    pass(string.format("%s -> %dx%d PNG", label, w, h))
+  end
+end
+
+check_convert("JPEG converts to PNG", "test.jpg")
+check_convert("WebP converts to PNG", "test.webp")
+
+-- ---------------------------------------------------------------------------
+-- Native PNG needs no conversion and transmits
+-- ---------------------------------------------------------------------------
+
+do
+  local label = "PNG transmits without conversion"
+  local path = fresh_copy "test.png"
+  if not image.is_native_format(path) then
+    fail(label, "PNG should be native")
+  else
+    local id = image.transmit_image(path)
+    if type(id) == "number" and id > 0 then
+      pass(string.format("%s -> image id %d", label, id))
+    else
+      fail(label, "no image id (got " .. vim.inspect(id) .. ")")
+    end
+  end
+end
+
+-- ---------------------------------------------------------------------------
+
+vim.api.nvim_ui_send = real_ui_send
+image._set_kitty_supported(nil)
+vim.fn.delete(tmp, "rf")
+
+print(string.format("\nmedia_test: %d passed, %d failed, %d skipped", pass_count, fail_count, skip_count))
+if fail_count > 0 then os.exit(1) end

--- a/tests/run_visual_test.sh
+++ b/tests/run_visual_test.sh
@@ -28,6 +28,7 @@ MODE="${1:-capture}"  # capture, --update, --compare
 SSIM_THRESHOLD="0.95"  # minimum acceptable similarity (0-1)
 
 # Terminal window geometry (in cells)
+WINDOW_TITLE="md-render-visual-test"
 WIN_COLS=120
 WIN_ROWS=40
 
@@ -71,28 +72,28 @@ wait_for_ready() {
   return 0
 }
 
-# Capture screenshot of a window owned by the given PID (macOS, via Quartz)
+# Capture a single terminal window by its title (macOS, via Quartz).
+#
+# Title, not PID: terminals re-exec, so the PID this script holds is often not
+# the one owning the window. Every launcher below passes WINDOW_TITLE.
+#
+# There is deliberately no full-screen fallback. The previous one fired
+# whenever PyObjC was missing and wrote a photograph of the whole desktop out
+# as a reference image.
 capture_screenshot() {
   local output_path="$1"
-  local term_pid="$2"
 
-  if python3 "$SCRIPT_DIR/capture_window.py" "$term_pid" "$output_path" 2>/dev/null; then
-    if [ -f "$output_path" ] && [ -s "$output_path" ]; then
-      return 0
-    fi
+  if ! python3 "$SCRIPT_DIR/capture_window.py" --title "$WINDOW_TITLE" "$output_path"; then
+    err "Could not capture the terminal window. Both of these are required:"
+    err "  pip install pyobjc-framework-Quartz"
+    err "  System Settings > Privacy & Security > Screen Recording"
+    return 1
   fi
-
-  # Fallback: try screencapture with accessibility permissions prompt
-  log "Trying screencapture (may require screen recording permission)..."
-  if screencapture -x "$output_path" 2>/dev/null; then
-    if [ -f "$output_path" ] && [ -s "$output_path" ]; then
-      return 0
-    fi
+  if [ ! -s "$output_path" ]; then
+    err "Capture produced an empty file: $output_path"
+    return 1
   fi
-
-  err "Could not capture screenshot. Grant screen recording permission in:"
-  err "  System Settings > Privacy & Security > Screen Recording"
-  return 1
+  return 0
 }
 
 # Compare two images using ImageMagick SSIM
@@ -131,7 +132,7 @@ run_wezterm() {
   rm -f "$SIGNAL_FILE"
   : > "$SIGNAL_FILE"  # Ensure it exists but is empty
 
-  VISUAL_TEST_SIGNAL="$SIGNAL_FILE" wezterm start \
+  VISUAL_TEST_SIGNAL="$SIGNAL_FILE" VISUAL_TEST_TITLE="$WINDOW_TITLE" wezterm start \
     --always-new-process \
     --cwd "$PLUGIN_ROOT" \
     -- nvim -u "$PLUGIN_ROOT/tests/visual_test_init.lua" &
@@ -143,7 +144,7 @@ run_wezterm() {
   gui_pid=$(pgrep -f "wezterm-gui" | head -1 || echo "$term_pid")
 
   if wait_for_ready 20; then
-    capture_screenshot "$SCREENSHOT_DIR/wezterm.png" "$gui_pid"
+    capture_screenshot "$SCREENSHOT_DIR/wezterm.png"
     log "WezTerm screenshot saved: $SCREENSHOT_DIR/wezterm.png"
   else
     err "WezTerm test timed out"
@@ -159,7 +160,7 @@ run_kitty() {
   rm -f "$SIGNAL_FILE"
   : > "$SIGNAL_FILE"
 
-  VISUAL_TEST_SIGNAL="$SIGNAL_FILE" kitty \
+  VISUAL_TEST_SIGNAL="$SIGNAL_FILE" VISUAL_TEST_TITLE="$WINDOW_TITLE" kitty \
     --override "initial_window_width=${WIN_COLS}c" \
     --override "initial_window_height=${WIN_ROWS}c" \
     --override "allow_remote_control=yes" \
@@ -168,7 +169,7 @@ run_kitty() {
   local term_pid=$!
 
   if wait_for_ready 20; then
-    capture_screenshot "$SCREENSHOT_DIR/kitty.png" "$term_pid"
+    capture_screenshot "$SCREENSHOT_DIR/kitty.png"
     log "Kitty screenshot saved: $SCREENSHOT_DIR/kitty.png"
   else
     err "Kitty test timed out"
@@ -182,12 +183,12 @@ run_ghostty() {
   rm -f "$SIGNAL_FILE"
   : > "$SIGNAL_FILE"
 
-  VISUAL_TEST_SIGNAL="$SIGNAL_FILE" ghostty \
+  VISUAL_TEST_SIGNAL="$SIGNAL_FILE" VISUAL_TEST_TITLE="$WINDOW_TITLE" ghostty \
     -e nvim -u "$PLUGIN_ROOT/tests/visual_test_init.lua" &
   local term_pid=$!
 
   if wait_for_ready 20; then
-    capture_screenshot "$SCREENSHOT_DIR/ghostty.png" "$term_pid"
+    capture_screenshot "$SCREENSHOT_DIR/ghostty.png"
     log "Ghostty screenshot saved: $SCREENSHOT_DIR/ghostty.png"
   else
     err "Ghostty test timed out"

--- a/tests/visual_test_init.lua
+++ b/tests/visual_test_init.lua
@@ -2,6 +2,15 @@
 -- Loads md-render.nvim from the current working directory,
 -- opens the test markdown file, and triggers preview after images load.
 
+-- Name the terminal window so capture_window.py can find exactly this one.
+--
+-- Done from Neovim (OSC 2 via 'title') rather than with per-terminal flags:
+-- every supported terminal honours it, whereas the flags differ and some do
+-- not set the name macOS reports (WezTerm's --class is the window class, not
+-- the title). VISUAL_TEST_TITLE is set by run_visual_test.sh.
+vim.opt.title = true
+vim.opt.titlestring = vim.env.VISUAL_TEST_TITLE or "md-render-visual-test"
+
 -- Add plugin to runtimepath
 local plugin_root = vim.fn.getcwd()
 vim.opt.runtimepath:prepend(plugin_root)


### PR DESCRIPTION
Follow-up to #36 / #37 — the testing gap that let that bug ship.

## The gap

Everything in `tests/` checked the bytes md-render **emits**. Nothing checked that the commands it **runs** still work. So when FFmpeg 9 removed `-vsync`, every video and animated GIF stopped rendering and no test noticed: the escape sequences were still correct, and no commit had touched the code.

The failure mode was *the toolchain moving*, not the repo changing — so a push-triggered test could never have caught it either.

## Layer 2: `tests/media_test.lua`

Invokes ffmpeg / ffprobe / ImageMagick / sips on the bundled `assets/demo/` files and asserts frames and PNGs actually come out. Two details keep it from being decorative:

- **It forces a cache miss.** The frame cache and converted-PNG cache are keyed on a hash of the source path, so testing a bundled path directly would hit a cache from an earlier run and never invoke the tool. Each asset is copied to a unique temp path first.
- **It cannot pass by not testing.** A missing tool prints `skip` so contributors without ffmpeg can still run `make test`; CI sets `MD_RENDER_REQUIRE_MEDIA_TOOLS=1`, which turns every skip into a failure.

It prints the version of every tool it found, so a red matrix immediately says *which* toolchain went red.

## The matrix

`.github/workflows/media.yml`: FFmpeg **6.1 / 7.1 / 8.1 / 9.0 / master**, on push, PR, and weekly.

Spanning majors is the whole point:

| install method | version | would it have caught `-vsync`? |
|---|---|---|
| `apt-get install ffmpeg` on ubuntu-24.04 | 6.1.1 | **no** — 6.1 still has `-vsync` |
| `brew install ffmpeg` on macos | 9.0.1 | yes, but only by luck of Homebrew tracking latest |

8.x/9.x/master come from BtbN's rolling `latest` release, so the scheduled run picks up new point releases and reports drift. 6.1/7.1 come from a pinned older autobuild — BtbN drops EOL branches from `latest`, but release assets stay reachable.

A failing **scheduled** run opens (or comments on) an issue labelled `toolchain`. A cron nobody hears about is not a test.

### Verification

Re-introducing `-vsync` locally:

```
FAIL animated GIF extracts frames -- expected >= 2 frames, got nil
FAIL MP4 video extracts frames    -- expected >= 2 frames, got nil
ok   JPEG converts to PNG -> 2000x1500 PNG      <- static path unaffected, as in the real incident
```

And with the tools hidden plus `MD_RENDER_REQUIRE_MEDIA_TOOLS=1`: `3 passed, 3 failed, 0 skipped`.

## Layer 3 repair

The visual-regression capture was broken in a way that mattered. It looked up the window by PID, but terminals re-exec, so the PID the script holds usually does not own the window — and it then **fell through to a full-screen capture**, silently photographing the whole desktop and writing it out as a reference image. I hit this while investigating; it produced an 8 MB screenshot of the entire display.

- Match on the window **title**, set from Neovim via `'title'` (OSC 2). Every supported terminal honours it, while the per-terminal flags differ and don't all set the name macOS reports (WezTerm's `--class` is the window class).
- **No fallback.** A capture that cannot be scoped to one window is now a hard error naming the two prerequisites (PyObjC, Screen Recording permission).

Verified end-to-end: the kitty leg now captures a correctly scoped window.

## Docs

`tests/README.md` gets the three-layer table, the rationale for each, and a note that much of what people reach for screenshots for (is the heading a two-row multicell group?) is answerable from `kitty @ get-text` with no pixels and no timing flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)