### PR TITLE
fix(text-size): detect Kitty without vim.tty.request, which 0.12 lacks

### DIFF
--- a/lua/md-render/text_size.lua
+++ b/lua/md-render/text_size.lua
@@ -56,28 +56,57 @@ end
 
 local _supported = nil
 
+--- How long to wait for the terminal to identify itself.
+---
+--- Only paid in full by a terminal that never answers; a reply short-circuits
+--- the wait. Kitty answers in ~120 ms on a warm desktop but was measured at
+--- ~260 ms inside a container under Xvfb, so a tight bound silently disables
+--- the feature on slow machines — which is indistinguishable, from the user's
+--- side, from the terminal not supporting it.
+local PROBE_TIMEOUT_MS = 1000
+
 --- Ask the terminal to identify itself (XTVERSION) and accept only Kitty >= 0.40.
 --- Returns nil when the terminal stays silent, which is treated as "no".
+---
+--- Implemented directly on `TermResponse` + `nvim_ui_send` rather than through
+--- `vim.tty.request`, which does not exist before Neovim 0.13 — on 0.12
+--- `vim.tty` only carries `query`. Depending on it made the whole feature a
+--- silent no-op on the oldest Neovim this plugin supports.
 ---@return boolean?
 local function probe_xtversion()
-  local ok, tty = pcall(require, "vim.tty")
-  if not ok or type(tty) ~= "table" or type(tty.request) ~= "function" then return nil end
+  if type(vim.api.nvim_ui_send) ~= "function" then return nil end
+
   local result = nil
-  pcall(tty.request, "\x1b[>0q", { timeout = 200 }, function(resp)
-    if type(resp) ~= "string" then return end
-    local major, minor = resp:match "kitty%((%d+)%.(%d+)"
-    if not major then
-      -- Some other terminal answered. Do not retry, do not guess.
-      result = false
-      return true
-    end
-    major, minor = tonumber(major), tonumber(minor)
-    result = (major > 0) or (minor >= 40)
-    return true
-  end)
-  vim.wait(250, function()
+  local ok_au, id = pcall(vim.api.nvim_create_autocmd, "TermResponse", {
+    nested = true,
+    callback = function(ev)
+      -- `ev.data` is a table carrying `sequence` on 0.12 and 0.13; accept a
+      -- bare string too in case that ever changes back.
+      local resp = ev.data
+      if type(resp) == "table" then resp = resp.sequence end
+      if type(resp) ~= "string" then return end
+
+      local major, minor = resp:match "kitty%((%d+)%.(%d+)"
+      if major then
+        result = (tonumber(major) > 0) or (tonumber(minor) >= 40)
+        return true
+      end
+      -- Some other terminal answered XTVERSION. Do not retry, do not guess.
+      if resp:match "^\27P>|" then
+        result = false
+        return true
+      end
+      -- Anything else is an unrelated response (cursor position, colours, the
+      -- primary device attributes that follow); keep listening.
+    end,
+  })
+  if not ok_au then return nil end
+
+  vim.api.nvim_ui_send "\27[>0q"
+  vim.wait(PROBE_TIMEOUT_MS, function()
     return result ~= nil
   end, 10)
+  pcall(vim.api.nvim_del_autocmd, id)
   return result
 end
 


### PR DESCRIPTION
Found while spiking the Linux/Xvfb and `kitty @ get-text` test layers.

## The bug

Scaled headings ([#40](https://github.com/delphinus/md-render.nvim/pull/40), shipped in v3.6.0) **never activated on Neovim 0.12** — the oldest version this plugin supports.

The terminal probe went through `vim.tty.request`, which only exists from 0.13. On 0.12, `vim.tty` carries just `query`:

```
nvim 0.12.5  -> vim.tty keys: { "query" }
nvim 0.13-dev -> vim.tty keys: { "request", "query", "_get_termdefs", "query_apc" }
```

The guard treated the missing function as "cannot probe", so `supports()` returned false and the feature was a silent no-op — indistinguishable from a terminal that does not implement OSC 66. It worked on my machine only because I am on 0.13-dev.

## The fix

Probe directly with `TermResponse` + `nvim_ui_send`, both present on 0.12 and 0.13. Verified the event shape is the same on both (`ev.data` is a table carrying `sequence`); a bare string is still accepted defensively.

Also raise the wait from 250 ms to **1000 ms**. Measured XTVERSION latency:

| environment | reply |
|---|---|
| kitty on a warm macOS desktop | ~120 ms |
| kitty under Xvfb in a container | **~260 ms** |

So the old bound was already past marginal, and a slow machine would silently lose the feature — the same indistinguishable failure. Only a terminal that never answers pays the full timeout, once per session, and only when the feature is enabled.

## Verification

Ubuntu 24.04 container, kitty 0.48.2 (from the release tarball — Ubuntu ships 0.32, too old for OSC 66), Neovim 0.12.5, Xvfb + software GL:

```
before: supports=false  placements=0
after:  supports=true   placements=2  drawn=2
```

and `kitty @ get-text --extent screen --ansi` recovers the sequences exactly:

```
meta='s=2' text='First Heading'
meta='s=2' text='Second Heading'
```

Note the icon is absent from the payload, as intended.

No regression locally (Neovim 0.13-dev + kitty 0.48.2: 6 placements, 5 drawn, unchanged) and WezTerm is still correctly refused (`supports=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)