### PR TITLE
test(terminal): assert on Kitty's cells, and matrix Neovim versions

### DIFF
--- a/.github/workflows/terminal.yml
+++ b/.github/workflows/terminal.yml
@@ -1,0 +1,101 @@
+name: Terminal
+
+# Drives a real Kitty under Xvfb and asserts on what the terminal actually
+# holds, using `kitty @ get-text --ansi` — which round-trips OSC 66 verbatim,
+# so "is this heading drawn at double size" is an exact string match rather
+# than a screenshot comparison.
+#
+# This is the layer between the unit tests (the bytes md-render emits) and the
+# visual regression tests (pixels, macOS-local only). It catches the two things
+# that actually went wrong with scaled headings: the level icon leaking into a
+# scaled run and being clipped, and the terminal probe silently failing.
+#
+# Same shape as the FFmpeg matrix: a pinned floor plus a version that follows
+# upstream, so both "we broke the oldest supported setup" and "upstream moved
+# under us" are visible. The schedule is for the second kind, which no push
+# would ever trigger.
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Mondays 03:30 UTC, half an hour after the media matrix.
+    - cron: "30 3 * * 1"
+  workflow_dispatch:
+
+jobs:
+  kitty-matrix:
+    name: kitty ${{ matrix.kitty }} / nvim ${{ matrix.nvim }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 0.40.0 introduced the text sizing protocol, so it is the floor this
+        # feature can possibly work on. `latest` is resolved at run time.
+        kitty: ["0.40.0", "latest"]
+        # v0.12.0 is the declared minimum and differs from stable in ways that
+        # matter here; nightly is the early warning.
+        nvim: [v0.12.0, nightly]
+    continue-on-error: ${{ matrix.nvim == 'nightly' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.nvim }}
+
+      # Kitty needs fontconfig and at least one font or it aborts at startup
+      # with "Failed to find and load fontconfig"; Noto CJK covers the CJK
+      # heading in the fixture. Ubuntu's own kitty package is 0.32, far below
+      # the 0.40 the text sizing protocol needs, so take the release tarball.
+      - name: Install Kitty ${{ matrix.kitty }} and Xvfb
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            xvfb libgl1-mesa-dri xauth fontconfig fonts-dejavu-core fonts-noto-cjk
+          version='${{ matrix.kitty }}'
+          if [ "$version" = latest ]; then
+            version="$(curl -fsSL https://api.github.com/repos/kovidgoyal/kitty/releases/latest \
+              | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p' | head -1)"
+          fi
+          echo "Using kitty $version"
+          curl -fsSL -o /tmp/kitty.txz \
+            "https://github.com/kovidgoyal/kitty/releases/download/v${version}/kitty-${version}-x86_64.txz"
+          sudo mkdir -p /opt/kitty
+          sudo tar -xJf /tmp/kitty.txz -C /opt/kitty
+          echo "/opt/kitty/bin" >> "$GITHUB_PATH"
+
+      - name: Report versions
+        run: |
+          kitty --version
+          nvim --version | head -1
+
+      - name: Run terminal tests
+        run: python3 tests/terminal_test.py
+
+  notify:
+    name: Open an issue on scheduled failure
+    needs: kitty-matrix
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = "Scheduled terminal test failed";
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { data: open } = await github.rest.issues.listForRepo({
+              ...context.repo, state: "open", labels: "toolchain",
+            });
+            const existing = open.find(i => i.title === title);
+            const body = `The weekly Kitty matrix failed. The terminal or Neovim most likely changed under us.\n\n${url}`;
+            if (existing) {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: existing.number, body });
+            } else {
+              await github.rest.issues.create({ ...context.repo, title, body, labels: ["toolchain"] });
+            }

--- a/.github/workflows/terminal.yml
+++ b/.github/workflows/terminal.yml
@@ -46,16 +46,20 @@ jobs:
           neovim: true
           version: ${{ matrix.nvim }}
 
-      # Kitty needs fontconfig and at least one font or it aborts at startup
-      # with "Failed to find and load fontconfig"; Noto CJK covers the CJK
-      # heading in the fixture. Ubuntu's own kitty package is 0.32, far below
-      # the 0.40 the text sizing protocol needs, so take the release tarball.
+      # Kitty is dynamically linked against the usual X client libraries and
+      # dlopens its GLFW backend, so a missing one is a startup failure rather
+      # than a link error: without libXcursor it dies with
+      #   Failed to dlopen .../kitty.glfw-x11.so: libXcursor.so.1: cannot open
+      # It also needs fontconfig and at least one font, and Noto CJK covers the
+      # CJK heading in the fixture. Ubuntu's own kitty package is 0.32, far
+      # below the 0.40 the text sizing protocol needs, so take the tarball.
       - name: Install Kitty ${{ matrix.kitty }} and Xvfb
         run: |
           set -euxo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            xvfb libgl1-mesa-dri xauth fontconfig fonts-dejavu-core fonts-noto-cjk
+            xvfb libgl1-mesa-dri xauth fontconfig fonts-dejavu-core fonts-noto-cjk \
+            libxcursor1 libxrandr2 libxi6 libxinerama1 libxkbcommon-x11-0 libdbus-1-3
           version='${{ matrix.kitty }}'
           if [ "$version" = latest ]; then
             version="$(curl -fsSL https://api.github.com/repos/kovidgoyal/kitty/releases/latest \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,16 +2,28 @@ name: Tests
 on: [push, pull_request]
 jobs:
   test:
+    name: nvim ${{ matrix.nvim }} / ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        # v0.12.0 is the minimum this plugin claims to support and is not the
+        # same as stable: `vim.tty.request` only appeared in 0.13, and a probe
+        # that depended on it silently disabled scaled headings on every 0.12.
+        # Testing only `stable` hid that for an entire release.
+        nvim: [v0.12.0, stable, nightly]
     runs-on: ${{ matrix.os }}
+    # A broken nightly is Neovim's problem, not this repo's; keep it visible
+    # without blocking merges.
+    continue-on-error: ${{ matrix.nvim == 'nightly' }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Neovim
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: stable
+          version: ${{ matrix.nvim }}
+      - name: Report version
+        run: nvim --version | head -1
       - name: Run tests
         run: make test

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,7 +6,8 @@
 |-------|------|---------|-------|-----|
 | 1. Unit tests | The bytes md-render *emits* | Protocol regressions | CI (push/PR) | `make test` |
 | 2. Media tools | The commands md-render *runs* | An external tool changing under us | CI (push/PR **and weekly**) | `nvim --headless -u NONE --noplugin -l tests/media_test.lua` |
-| 3. Visual regression | What the terminal actually *draws* | Clipped glyphs, images that never paint | Local only | `./tests/run_visual_test.sh` |
+| 3. Terminal | What the terminal actually *holds* | Scaled text drawn wrong, or not at all | CI (push/PR **and weekly**) | `tests/terminal_test.py` |
+| 4. Visual regression | What the terminal actually *draws* | Clipped glyphs, images that never paint | Local only | `./tests/run_visual_test.sh` |
 
 Layer 2 exists because of a silent breakage: FFmpeg 9 removed `-vsync`, frame extraction failed for every video and animated GIF, and nothing noticed — the emitted escape sequences were still correct and no commit had touched the code. The failure mode was the toolchain moving, so the test runs on a schedule, not just on push.
 
@@ -48,7 +49,23 @@ The test prints the version of each tool it found; when the matrix goes red the 
 
 Spanning majors is the point. Ubuntu 24.04 still ships FFmpeg 6.1, so a job that ran `apt-get install ffmpeg` would have stayed green through the entire `-vsync` incident. The 8.x/9.x/master entries point at BtbN's rolling `latest` release, so the scheduled run picks up new point releases and reports drift; 6.1 and 7.1 come from a pinned older autobuild, because BtbN drops EOL branches from `latest` while keeping the release assets reachable.
 
-## Layer 3: Visual regression tests
+## Layer 3: Terminal tests
+
+`terminal_test.py` launches a real Kitty (under `xvfb-run` when present), runs Neovim with the plugin, and asserts on what the terminal ended up holding.
+
+The trick that makes this cheap is that `kitty @ get-text --ansi` **round-trips OSC 66 verbatim**:
+
+```
+ESC ] 66 ; s=2 ; Short Heading ESC \
+```
+
+So "is this heading drawn at double size" is an exact string match — no screenshot, no SSIM, and none of the font or timing sensitivity of comparing images. It asserts that `#`/`##` scale and `###` does not, that a long CJK heading wraps into several scaled blocks instead of falling back to plain size, that the level icon stays out of the payload (it gets clipped inside a scaled run), and that nothing is scaled when the feature is off.
+
+`.github/workflows/terminal.yml` runs it against Kitty **0.40.0** (the version that introduced the protocol, so the floor this can work on) and **latest**, crossed with Neovim **v0.12.0** and **nightly**, plus a weekly schedule.
+
+Ubuntu's own kitty package is 0.32 — below the 0.40 the protocol needs — so the workflow takes the release tarball. Kitty also needs `fontconfig` and at least one font installed or it aborts at startup.
+
+## Layer 4: Visual regression tests
 
 Screenshot-based tests that launch real terminal emulators and compare rendered output against reference images.
 
@@ -60,7 +77,7 @@ Screenshot-based tests that launch real terminal emulators and compare rendered 
 - **PyObjC**: `pip install pyobjc-framework-Quartz`. Without it the capture cannot be scoped to one window and the script aborts.
 - **Screen Recording permission** for whatever runs the script (System Settings > Privacy & Security > Screen Recording)
 
-This layer is a deliberate gate, not something to run on every save: it opens GUI windows and takes over the screen while it runs, and a whole-window SSIM is sensitive to font, colorscheme and OS updates.
+This layer is a deliberate gate, not something to run on every save. Most questions people reach for a screenshot to answer are cheaper in layer 3: it opens GUI windows and takes over the screen while it runs, and a whole-window SSIM is sensitive to font, colorscheme and OS updates.
 
 ### Usage
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,7 +63,7 @@ So "is this heading drawn at double size" is an exact string match — no screen
 
 `.github/workflows/terminal.yml` runs it against Kitty **0.40.0** (the version that introduced the protocol, so the floor this can work on) and **latest**, crossed with Neovim **v0.12.0** and **nightly**, plus a weekly schedule.
 
-Ubuntu's own kitty package is 0.32 — below the 0.40 the protocol needs — so the workflow takes the release tarball. Kitty also needs `fontconfig` and at least one font installed or it aborts at startup.
+Ubuntu's own kitty package is 0.32 — below the 0.40 the protocol needs — so the workflow takes the release tarball. Kitty then needs its runtime dependencies installed by hand: `fontconfig` plus a font, and the X client libraries it `dlopen`s (`libxcursor1`, `libxrandr2`, `libxi6`, `libxinerama1`, `libxkbcommon-x11-0`). A missing one is a startup failure, not a link error — without libXcursor kitty dies with `Failed to dlopen .../kitty.glfw-x11.so`.
 
 ## Layer 4: Visual regression tests
 

--- a/tests/fixtures/text_size_e2e.md
+++ b/tests/fixtures/text_size_e2e.md
@@ -1,0 +1,21 @@
+# Short Heading
+
+Body text under the first heading. This paragraph is deliberately wide so the
+floating preview is sized generously enough for a doubled heading to fit.
+
+## Second Level
+
+More body text, also long enough to keep the preview window comfortably wide
+while the assertions run.
+
+## あいうえお かきくけこ さしすせそ たちつてと なにぬねの はひふへほ まみむめも
+
+A long CJK heading sits above. At double width it cannot fit on one line, so it
+must wrap into several scaled blocks rather than silently falling back to plain
+size.
+
+### Third Level Stays Plain
+
+Only `#` and `##` scale, so this heading must never appear in a scaled run.
+
+Tail text.

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Terminal end-to-end test: drive a real Kitty and assert on what it actually holds.
+
+Sits between the unit tests (which check the bytes md-render emits) and the
+visual regression tests (which compare pixels). The trick that makes this layer
+cheap is that `kitty @ get-text --ansi` round-trips OSC 66 verbatim:
+
+    ESC ] 66 ; s=2 ; Short Heading ESC \\
+
+So "is this heading drawn at double size" is answerable as an exact string
+match, with no screenshot, no SSIM, and none of the font or timing sensitivity
+that comes with comparing images.
+
+Usage:
+    tests/terminal_test.py                 # auto-detect kitty, use xvfb if present
+    tests/terminal_test.py --kitty /path/to/kitty
+
+Exits non-zero on failure.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import signal as signal_mod
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# nf-md-format_header_1 .. _3. Kitty gives a scaled run exactly `scale` cells
+# per source cell while reporting these as one cell wide, so an icon inside a
+# run gets clipped and renders as a bare "H". They must stay out of the payload.
+HEADING_ICONS = ["\U000f026b", "\U000f026c", "\U000f026d"]
+
+OSC66 = re.compile(rb"\x1b\]66;([^;]*);(.*?)(?:\x1b\\|\x07)", re.S)
+
+passed = failed = 0
+
+
+def ok(msg):
+    global passed
+    passed += 1
+    print(f"  ok   {msg}")
+
+
+def bad(msg, detail=None):
+    global failed
+    failed += 1
+    print(f"  FAIL {msg}")
+    if detail:
+        print(f"       {detail}")
+
+
+def run_kitty(kitty, enabled, workdir):
+    """Launch kitty+nvim, wait for the signal, return (scaled_runs, diagnostics)."""
+    # A socket per run. Sharing one path lets a query land on a previous
+    # instance that has not finished dying, which reads as "scaled text is
+    # still on screen after being disabled".
+    sock = workdir / f"sock-{int(enabled)}"
+    signal = workdir / f"ready-{int(enabled)}"
+    diag = workdir / f"diag-{int(enabled)}"
+
+    env = dict(
+        os.environ,
+        MD_RENDER_E2E_ENABLED="1" if enabled else "0",
+        MD_RENDER_E2E_SIGNAL=str(signal),
+        MD_RENDER_E2E_DIAG=str(diag),
+        # Kitty needs a GL context; CI has no GPU.
+        LIBGL_ALWAYS_SOFTWARE="1",
+    )
+
+    cmd = [
+        kitty,
+        "-o", "allow_remote_control=yes",
+        # A window narrow enough makes the preview float narrow enough that the
+        # minimum-width guard declines to scale anything, which would look like
+        # a failure. Ask for room.
+        "-o", "font_size=10",
+        "--listen-on", f"unix:{sock}",
+        "--directory", str(REPO),
+        "nvim", "--clean", "-u", str(REPO / "tests/text_size_e2e_init.lua"),
+    ]
+    if shutil.which("xvfb-run"):
+        cmd = ["xvfb-run", "-a", "--server-args=-screen 0 2400x1400x24"] + cmd
+
+    # New session so the whole tree can be signalled: under xvfb-run the
+    # process here is the wrapper, and killing it leaves kitty running.
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env, start_new_session=True
+    )
+    try:
+        deadline = time.time() + 90
+        while time.time() < deadline and not signal.exists():
+            if proc.poll() is not None:
+                raise RuntimeError(f"kitty exited early with code {proc.returncode}")
+            time.sleep(0.5)
+        if not signal.exists():
+            raise RuntimeError("timed out waiting for the preview to settle")
+
+        out = subprocess.run(
+            [kitty, "@", "--to", f"unix:{sock}", "get-text", "--extent", "screen", "--ansi"],
+            capture_output=True, check=True, env=env,
+        ).stdout
+    finally:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal_mod.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
+        proc.wait(timeout=10)
+        # Do not let a slow teardown bleed into the next run.
+        for _ in range(20):
+            if not sock.exists():
+                break
+            time.sleep(0.25)
+
+    runs = [(m.decode(), t.decode("utf-8", "replace")) for m, t in OSC66.findall(out)]
+    return runs, (diag.read_text() if diag.exists() else "(no diagnostics)")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--kitty", default=shutil.which("kitty"))
+    args = ap.parse_args()
+
+    if not args.kitty:
+        sys.exit("error: kitty not found; pass --kitty")
+
+    version = subprocess.run([args.kitty, "--version"], capture_output=True, text=True).stdout.strip()
+    print(f"terminal_test environment:\n  {version}")
+    print(f"  xvfb: {'yes' if shutil.which('xvfb-run') else 'no (running against the real display)'}\n")
+
+    with tempfile.TemporaryDirectory() as td:
+        workdir = Path(td)
+
+        print("scaled headings ON:")
+        runs, diag = run_kitty(args.kitty, True, workdir)
+        print("".join(f"    {line}\n" for line in diag.strip().splitlines()), end="")
+
+        if not runs:
+            bad("kitty holds at least one scaled run", f"none found; diagnostics above")
+        else:
+            ok(f"kitty holds {len(runs)} scaled run(s)")
+
+        texts = [t for _, t in runs]
+
+        # Every run must be s=2: nothing else is supposed to emit OSC 66.
+        others = sorted({m for m, _ in runs if m != "s=2"})
+        if others:
+            bad("every scaled run is s=2", f"also saw {others}")
+        else:
+            ok("every scaled run is s=2")
+
+        # h1 and h2 scale.
+        for want in ("Short Heading", "Second Level"):
+            if any(want == t for t in texts):
+                ok(f"{want!r} is scaled")
+            else:
+                bad(f"{want!r} is scaled", f"payloads: {texts}")
+
+        # h3 never scales.
+        if any("Third Level" in t for t in texts):
+            bad("h3 is not scaled", f"payloads: {texts}")
+        else:
+            ok("h3 is not scaled")
+
+        # A long CJK heading wraps into several scaled blocks instead of
+        # falling back to plain size.
+        cjk = [t for t in texts if "あいうえお" in t or "まみむめも" in t]
+        if len(cjk) >= 2:
+            ok(f"long CJK heading wrapped into {len(cjk)} scaled blocks")
+        else:
+            bad("long CJK heading wraps into >= 2 scaled blocks", f"got {cjk}")
+
+        # The regression that shipped once: the level icon inside a scaled run
+        # is clipped by Kitty and renders as a bare "H".
+        leaked = [t for t in texts if any(icon in t for icon in HEADING_ICONS)]
+        if leaked:
+            bad("the level icon stays out of scaled runs", f"leaked into {leaked}")
+        else:
+            ok("the level icon stays out of scaled runs")
+
+        print("\nscaled headings OFF:")
+        runs_off, diag_off = run_kitty(args.kitty, False, workdir)
+        print("".join(f"    {line}\n" for line in diag_off.strip().splitlines()), end="")
+        if runs_off:
+            bad("nothing is scaled when disabled", f"found {runs_off}")
+        else:
+            ok("nothing is scaled when disabled")
+
+    print(f"\nterminal_test: {passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/terminal_test.py
+++ b/tests/terminal_test.py
@@ -88,25 +88,38 @@ def run_kitty(kitty, enabled, workdir):
     if shutil.which("xvfb-run"):
         cmd = ["xvfb-run", "-a", "--server-args=-screen 0 2400x1400x24"] + cmd
 
+    # Keep the terminal's own output: when kitty refuses to start (a missing
+    # shared library, no fonts) it says so there, and discarding it turns a
+    # one-line diagnosis into a blind hunt.
+    termlog = workdir / f"kitty-{int(enabled)}.log"
+    logf = termlog.open("wb")
     # New session so the whole tree can be signalled: under xvfb-run the
     # process here is the wrapper, and killing it leaves kitty running.
-    proc = subprocess.Popen(
-        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env, start_new_session=True
-    )
+    proc = subprocess.Popen(cmd, stdout=logf, stderr=subprocess.STDOUT, env=env, start_new_session=True)
     try:
         deadline = time.time() + 90
         while time.time() < deadline and not signal.exists():
             if proc.poll() is not None:
-                raise RuntimeError(f"kitty exited early with code {proc.returncode}")
+                logf.close()
+                raise RuntimeError(
+                    f"kitty exited early with code {proc.returncode}:\n"
+                    + (termlog.read_text(errors="replace").strip() or "(no output)")
+                )
             time.sleep(0.5)
         if not signal.exists():
-            raise RuntimeError("timed out waiting for the preview to settle")
+            logf.close()
+            raise RuntimeError(
+                "timed out waiting for the preview to settle:\n"
+                + (termlog.read_text(errors="replace").strip() or "(no output)")
+            )
 
         out = subprocess.run(
             [kitty, "@", "--to", f"unix:{sock}", "get-text", "--extent", "screen", "--ansi"],
             capture_output=True, check=True, env=env,
         ).stdout
     finally:
+        if not logf.closed:
+            logf.close()
         try:
             os.killpg(os.getpgid(proc.pid), signal_mod.SIGKILL)
         except (ProcessLookupError, PermissionError):

--- a/tests/text_size_e2e_init.lua
+++ b/tests/text_size_e2e_init.lua
@@ -1,0 +1,51 @@
+-- Neovim side of the terminal end-to-end test (see tests/terminal_test.py).
+--
+-- Opens the fixture in a preview with scaled headings either on or off, then
+-- writes a signal file so the driver knows the screen has settled instead of
+-- guessing with a fixed sleep.
+--
+-- Environment:
+--   MD_RENDER_E2E_ENABLED  "1" to turn scaled headings on
+--   MD_RENDER_E2E_SIGNAL   path to create once the preview has settled
+--   MD_RENDER_E2E_DIAG     path to write plugin-side diagnostics to
+
+local plugin_root = vim.fn.getcwd()
+vim.opt.runtimepath:prepend(plugin_root)
+vim.opt.termguicolors = true
+
+local text_size = require "md-render.text_size"
+text_size.setup { enabled = vim.env.MD_RENDER_E2E_ENABLED == "1" }
+
+local function write(path, body)
+  if not path then return end
+  local f = io.open(path, "w")
+  if not f then return end
+  f:write(body)
+  f:close()
+end
+
+vim.defer_fn(function()
+  local diag = { "supports=" .. tostring(text_size.supports()) }
+
+  vim.cmd("edit " .. plugin_root .. "/tests/fixtures/text_size_e2e.md")
+  vim.bo.filetype = "markdown"
+  local ok, err = pcall(function()
+    require("md-render").preview.show()
+  end)
+  table.insert(diag, "show_ok=" .. tostring(ok) .. " err=" .. tostring(err))
+
+  -- Let the paint debounce settle before the driver reads the screen.
+  vim.defer_fn(function()
+    local session
+    for _, s in pairs(require("md-render").preview._sessions) do
+      session = s
+    end
+    table.insert(diag, "placements=" .. tostring(session and #session.content.text_placements))
+    table.insert(diag, "drawn=" .. tostring(session and session.text_size_state and session.text_size_state.last_drawn))
+    table.insert(diag, "columns=" .. vim.o.columns)
+    table.insert(diag, "max_width=" .. tostring(session and session.opts.max_width))
+
+    write(vim.env.MD_RENDER_E2E_DIAG, table.concat(diag, "\n") .. "\n")
+    write(vim.env.MD_RENDER_E2E_SIGNAL, "ready\n")
+  end, 2000)
+end, 1000)


### PR DESCRIPTION
The two layers left over from the earlier spike. Between them they cover both bugs scaled headings shipped with.

## 1. Neovim matrix

`test.yml` ran `stable` only. That is exactly how [#41](https://github.com/delphinus/md-render.nvim/pull/41) happened: the probe depended on `vim.tty.request`, a 0.13 API, so CI stayed green while the feature was silently dead on every Neovim 0.12 — the minimum this plugin claims to support.

Now `v0.12.0` × `stable` × `nightly` × 2 OS. Nightly is `continue-on-error`: worth seeing, not worth blocking merges on.

## 2. Terminal tests

`tests/terminal_test.py` launches a real Kitty under Xvfb, runs Neovim with the plugin, and asserts on what the terminal ended up holding.

What makes this cheap rather than another screenshot suite: **`kitty @ get-text --ansi` round-trips OSC 66 verbatim.**

```
ESC ] 66 ; s=2 ; Short Heading ESC \
```

So "is this heading drawn at double size" is an exact string match — no SSIM, no font sensitivity, no timing phase. It asserts:

- `#` and `##` scale, `###` does not
- a long CJK heading wraps into several scaled blocks rather than falling back to plain size
- the level icon stays **out** of the payload (inside a scaled run Kitty clips it, and `󰉬` renders as a bare `H`)
- nothing is scaled when the feature is off

### It catches the real regressions

| reintroduced bug | result |
|---|---|
| icon back inside the scaled run | 3 failures, including `the level icon stays out of scaled runs` |
| `vim.tty.request` dependency, on nvim 0.12.5 | 4 failures, `supports=false` |

### Matrix

Kitty **0.40.0** (introduced the protocol, so the floor this can work on) and **latest**, crossed with Neovim **v0.12.0** and **nightly**, plus a weekly schedule — the same pinned-floor-plus-moving-head shape as the FFmpeg matrix, for the same reason: a push only ever catches the first kind of breakage.

Confirmed the suite passes on 0.40.0 as well as 0.48.2, so `get-text --ansi` reproducing OSC 66 is not a recent addition.

## Environment notes

Things that cost time to discover, now encoded in the workflow and `tests/README.md`:

- **Ubuntu's kitty package is 0.32** — below the 0.40 the protocol needs. The workflow takes the release tarball.
- **Kitty aborts at startup without fontconfig and a font** (`Failed to find and load fontconfig`).
- **A narrow terminal makes the preview float narrow**, and the minimum-width guard then declines to scale anything — which reads as a failure rather than as the guard working. The workflow asks for a large virtual screen.
- The driver kills the whole process group and uses a socket per run: under `xvfb-run` the process Python holds is the wrapper, and killing it leaves kitty alive, so a shared socket path let the second query land on the first instance.

## Cost

Matrix legs run in parallel, so wall clock is one leg, not the sum: ~1 min for the terminal job, unchanged for `test.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)