### PR TITLE
perf(images): one process per file, however many times it is asked for

### DIFF
--- a/lua/md-render/image.lua
+++ b/lua/md-render/image.lua
@@ -159,6 +159,48 @@ function M.get_cell_size()
 end
 
 -- ============================================================================
+-- Work already under way
+-- ============================================================================
+
+--- Renders and downloads in flight, keyed by the file they will produce.
+---
+--- The same image is asked for again long before the first request has
+--- answered. Rebuilding the content is what does it, and that happens for
+--- reasons that have nothing to do with the image: a resize reflows the text
+--- (`WinResized` → live rebuild), a fold or an expandable region toggles, and
+--- every burst of typing behind the live update in a split does too. Each ask
+--- used to start its own work — another JVM for a PlantUML diagram, another
+--- browser for a Mermaid one — and for a download, another curl writing over
+--- the file the first curl had not finished writing.
+---@type table<string, (fun(path: string?))[]>
+local _in_flight = {}
+
+--- Wait on the work already producing `key`, or claim it for this caller.
+---@param key string the file the work will produce
+---@param callback fun(path: string?)
+---@return boolean joined true when somebody is already on it and `callback` was queued
+local function join_work(key, callback)
+  local waiting = _in_flight[key]
+  if waiting then
+    table.insert(waiting, callback)
+    return true
+  end
+  _in_flight[key] = {}
+  return false
+end
+
+--- Hand the result to everyone who joined while the work was running.
+---@param key string
+---@param path string?
+local function finish_work(key, path)
+  local waiting = _in_flight[key]
+  _in_flight[key] = nil
+  for _, cb in ipairs(waiting or {}) do
+    cb(path)
+  end
+end
+
+-- ============================================================================
 -- Image dimension detection from file headers
 -- ============================================================================
 
@@ -503,10 +545,16 @@ function M.render_mermaid_async(source, callback)
     return
   end
 
+  if join_work(cache_path, callback) then return end
+  local function done(path)
+    callback(path)
+    finish_work(cache_path, path)
+  end
+
   local tmp_input = vim.fn.tempname() .. ".mmd"
   local f = io.open(tmp_input, "w")
   if not f then
-    callback(nil)
+    done(nil)
     return
   end
   f:write(source)
@@ -518,9 +566,9 @@ function M.render_mermaid_async(source, callback)
     vim.schedule(function()
       os.remove(tmp_input)
       if vim.fn.filereadable(cache_path) == 1 then
-        callback(cache_path)
+        done(cache_path)
       else
-        callback(nil)
+        done(nil)
       end
     end)
   end)
@@ -646,9 +694,15 @@ function M.render_plantuml_async(source, callback)
     return
   end
 
+  if join_work(cache_path, callback) then return end
+  local function done(path)
+    callback(path)
+    finish_work(cache_path, path)
+  end
+
   local cmd_prefix = find_plantuml()
   if not cmd_prefix then
-    render_plantuml_remote_async(source, cache_path, callback)
+    render_plantuml_remote_async(source, cache_path, done)
     return
   end
 
@@ -663,9 +717,9 @@ function M.render_plantuml_async(source, callback)
         end
       end
       if vim.fn.filereadable(cache_path) == 1 then
-        callback(cache_path)
+        done(cache_path)
       else
-        render_plantuml_remote_async(source, cache_path, callback)
+        render_plantuml_remote_async(source, cache_path, done)
       end
     end)
   end)
@@ -979,14 +1033,20 @@ function M.download_async(url, callback)
 
   local cache_path = url_to_cache_path(url)
 
+  if join_work(cache_path, callback) then return end
+  local function done(path)
+    callback(path)
+    finish_work(cache_path, path)
+  end
+
   -- Try custom download function first (e.g. for authenticated GitHub Enterprise URLs)
   if _custom_download_fn then
     local handled = _custom_download_fn(url, cache_path, function(ok)
       vim.schedule(function()
         if ok then
-          finalize_download(url, cache_path, callback)
+          finalize_download(url, cache_path, done)
         else
-          callback(nil)
+          done(nil)
         end
       end)
     end)
@@ -1000,10 +1060,10 @@ function M.download_async(url, callback)
     function(result)
       vim.schedule(function()
         if result.code == 0 then
-          finalize_download(url, cache_path, callback)
+          finalize_download(url, cache_path, done)
         else
           os.remove(cache_path)
-          callback(nil)
+          done(nil)
         end
       end)
     end
@@ -1037,16 +1097,22 @@ function M.download_video_async(url, callback)
 
   local cache_path = url_to_cache_path(url)
 
+  if join_work(cache_path, callback) then return end
+  local function done(path)
+    callback(path)
+    finish_work(cache_path, path)
+  end
+
   -- Try custom download function first (e.g. for authenticated GitHub Enterprise URLs)
   if _custom_download_fn then
     local handled = _custom_download_fn(url, cache_path, function(ok)
       vim.schedule(function()
         if ok and vim.fn.filereadable(cache_path) == 1 then
           _url_cache[url] = cache_path
-          callback(cache_path)
+          done(cache_path)
         else
           os.remove(cache_path)
-          callback(nil)
+          done(nil)
         end
       end)
     end)
@@ -1061,10 +1127,10 @@ function M.download_video_async(url, callback)
       vim.schedule(function()
         if result.code == 0 and vim.fn.filereadable(cache_path) == 1 then
           _url_cache[url] = cache_path
-          callback(cache_path)
+          done(cache_path)
         else
           os.remove(cache_path)
-          callback(nil)
+          done(nil)
         end
       end)
     end

--- a/tests/image_test.lua
+++ b/tests/image_test.lua
@@ -861,8 +861,63 @@ test("frame extract cmd: no -vsync / -fps_mode", function()
 end)
 
 -- ============================================================================
--- Summary
+-- One process per file, however many times it is asked for
 -- ============================================================================
+
+--- Stand in for `vim.system`, recording each spawn and handing back the
+--- completion callback so the test decides when the work finishes.
+---@return { spawns: integer, finish: fun(code: integer) }
+local function stub_vim_system()
+  local rec = { spawns = 0 }
+  local pending = {}
+  local real = vim.system
+  vim.system = function(_, _, on_exit)
+    rec.spawns = rec.spawns + 1
+    table.insert(pending, on_exit)
+    return { pid = 0 }
+  end
+  rec.finish = function(code)
+    local queued = pending
+    pending = {}
+    for _, on_exit in ipairs(queued) do
+      on_exit { code = code, stdout = "", stderr = "" }
+    end
+    vim.wait(100, function()
+      return false
+    end, 10)
+  end
+  rec.restore = function()
+    vim.system = real
+  end
+  return rec
+end
+
+test("download_async: asking for the same URL twice runs one curl", function()
+  local sys = stub_vim_system()
+  local url = "https://example.invalid/md-render-test-dedupe.png"
+  local answers = {}
+
+  image.download_async(url, function(path)
+    table.insert(answers, path or false)
+  end)
+  image.download_async(url, function(path)
+    table.insert(answers, path or false)
+  end)
+  assert_eq(sys.spawns, 1, "the second request joins the first instead of spawning another curl")
+  assert_eq(#answers, 0, "and nothing has answered yet")
+
+  -- Fail the download: the file never appears, so both callers get nil, which
+  -- is what proves the second one was queued rather than dropped.
+  sys.finish(1)
+  assert_eq(#answers, 2, "both callers are answered when the one download finishes")
+  assert_eq(answers, { false, false }, "both get the same result")
+
+  -- The key is released, so a later attempt is allowed to try again.
+  image.download_async(url, function() end)
+  assert_eq(sys.spawns, 2, "a request after the first finished starts fresh work")
+  sys.finish(1)
+  sys.restore()
+end)
 
 print(string.format("\n%d passed, %d failed", pass_count, fail_count))
 if fail_count > 0 then os.exit(1) end


### PR DESCRIPTION
Noticed while measuring the PlantUML support from #43.

Rebuilding the content asks for an image again long before the first request
has answered, and rebuilds happen for reasons that have nothing to do with the
image:

- `WinResized` reflows the text through a live rebuild (`preview.lua`);
- a fold or an expandable region toggles;
- the live update behind `:MdRender split` fires on every burst of typing.

Every one of those started its own work for an image already being produced.

For a diagram that is an entire extra process for a picture already being
drawn. `plantuml -tpng -pipe` measured 1.10–1.45s per invocation here, almost
all of it JVM startup — a 40-edge diagram costs the same as a two-line one —
so dragging a split border while one renders stacked several of them up.
Mermaid has the same shape with a heavier process behind it.

For a download it is not only wasteful: both curls run with `-o` pointed at the
same cache path, so the second writes over the file the first has not finished
writing.

Work is now tracked by the file it will produce, and a second request waits on
the first rather than starting its own. The key is released when the work
finishes, so a later attempt — after a failure, say — is free to try again.
Applies to `render_mermaid_async`, `render_plantuml_async`, `download_async`
and `download_video_async`.

`tests/image_test.lua` stubs `vim.system` and drives `download_async` twice
with the same URL: one spawn, both callers answered when it completes, and a
fresh spawn allowed afterwards. Without the change the first two assertions
fail (2 spawns, and the join never happens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)