### PR TITLE
fix(preview): accept frontmatter fences with trailing whitespace

### DIFF
--- a/lua/md-render/preview.lua
+++ b/lua/md-render/preview.lua
@@ -82,12 +82,18 @@ MdPreview.build_content = function(lines, opts)
 
   local b = ContentBuilder.new()
 
-  -- Detect and extract frontmatter
+  -- Detect and extract frontmatter.
+  --
+  -- Both fences tolerate trailing whitespace: editors that rewrite the
+  -- frontmatter block (Obsidian's property editor among them) can leave a
+  -- space behind, and requiring a bare `---` would drop the whole block back
+  -- into the body. There it renders as a thematic break followed by a setext
+  -- heading, because the closing fence underlines the last property line.
   local body_start = 1
-  if lines[1] and lines[1]:match "^%-%-%-$" then
+  if lines[1] and lines[1]:match "^%-%-%-%s*$" then
     local frontmatter_lines = {}
     for i = 2, #lines do
-      if lines[i]:match "^%-%-%-$" then
+      if lines[i]:match "^%-%-%-%s*$" then
         body_start = i + 1
         break
       end

--- a/tests/frontmatter_test.lua
+++ b/tests/frontmatter_test.lua
@@ -136,5 +136,37 @@ test("multiple overflowing entries get distinct block ids", function()
   assert_true(id1 < 0 and id2 < 0, "both block ids are negative")
 end)
 
+-- ----------------------------------------------------------------------
+-- Test 5: a fence carrying trailing whitespace still opens/closes the
+-- block. Without this the whole frontmatter falls through to the body,
+-- where the closing fence underlines the last property line as a setext
+-- heading.
+-- ----------------------------------------------------------------------
+test("fences tolerate trailing whitespace", function()
+  for _, fences in ipairs {
+    { open = "--- ", close = "---" },
+    { open = "---", close = "--- " },
+    { open = "---\t", close = "---  " },
+  } do
+    local lines = { fences.open, "k: v", fences.close, "", "body" }
+    local content = preview.build_content(lines, { max_width = 40 })
+    assert_eq(
+      content.lines[1],
+      "  Properties",
+      "'" .. fences.open .. "' / '" .. fences.close .. "' opens a Properties block"
+    )
+    assert_eq(content.lines[2], "  k: v", "the entry is rendered as a property")
+  end
+end)
+
+-- ----------------------------------------------------------------------
+-- Test 6: `----` is a thematic break, not a fence.
+-- ----------------------------------------------------------------------
+test("a four-dash rule is not a frontmatter fence", function()
+  local lines = { "----", "k: v", "----", "", "body" }
+  local content = preview.build_content(lines, { max_width = 40 })
+  assert_true(content.lines[1] ~= "  Properties", "no Properties block for a four-dash rule")
+end)
+
 print(string.format("\n%d passed, %d failed", pass_count, fail_count))
 if fail_count > 0 then vim.cmd "cquit 1" end


### PR DESCRIPTION
An Obsidian note rendered its whole frontmatter as document body: the opening
`---` came out as a thematic break, the properties as a paragraph and a list,
and `tags: []` as an H2 — the closing `---` had underlined it as a setext
heading.

The cause is the fence pattern. Both fences had to be a bare `---`, so a single
trailing space on either line takes `body_start` to 1 and the block falls
through to `render_document`. Editors that rewrite the frontmatter can leave
that space behind; Obsidian's property editor is the one in reach here.

Both fences now match `^---%s*$`.

## Why lenient

There is no frontmatter spec — neither CommonMark nor GFM has one, and each
implementation re-derives the Jekyll convention slightly differently. Measured
and cited:

| implementation | trailing whitespace | note |
|---|---|---|
| tree-sitter-markdown | **accepted** on both fences | rejects `...` as a closing fence. Measured against the parser Neovim loads for these buffers |
| Jekyll | **accepted** on both fences | `\A(---\s*\n.*?\n?)^((---\|\.\.\.)\s*$\n?)` in `lib/jekyll/document.rb`; also takes `...` |
| obsidian.nvim | rejected | `^%-%-%-+$`; accepts four or more dashes instead |
| YAML 1.2 | — | `---` is the directives-end marker, trailing spaces are insignificant |

Matching tree-sitter keeps the renderer's reading of a buffer and Neovim's own
parse of it from diverging. The rejecting behaviour also fails badly rather
than conservatively: nothing is flagged, and the output is unrelated to the
input. A read-only renderer has little to gain from the strictness.

Deliberately left out, tracking tree-sitter: `...` as a closing fence (Jekyll
takes it, tree-sitter does not, and nobody writes it in Obsidian), and `----`
as a fence (obsidian.nvim takes it; it collides with a thematic break). A test
pins `----` as a thematic break.

## Tests

`tests/frontmatter_test.lua` gains the whitespace combinations and the `----`
case. `make test` passes.
