### PR TITLE
ci(media): re-pin the FFmpeg 6.1 and 7.1 builds that BtbN deleted

### DIFF
--- a/.github/workflows/media.yml
+++ b/.github/workflows/media.yml
@@ -29,13 +29,26 @@ jobs:
       fail-fast: false
       matrix:
         ffmpeg:
-          # 6.x and 7.x come from a pinned old autobuild: BtbN drops branches
-          # from its rolling `latest` release once they go EOL, but release
-          # assets themselves persist, so these URLs stay valid.
+          # 6.x and 7.x come from pinned old autobuilds: BtbN drops branches
+          # from its rolling `latest` release once they go EOL.
+          #
+          # These pins expire. BtbN deletes whole autobuild releases, assets
+          # and all, keeping roughly the last two weeks of dailies plus a
+          # monthly snapshot going back about two years — so an EOL branch
+          # survives only as long as the newest snapshot that still carries
+          # it. Each URL below is the newest one that does, which is not the
+          # same release for both. When one 404s, re-pin it to the newest
+          # snapshot whose assets still list that branch:
+          #
+          #   gh api "repos/BtbN/FFmpeg-Builds/releases?per_page=100" \
+          #     -q '.[] | .tag_name + " " +
+          #         ([.assets[].name | select(test("linux64-gpl-6\\."))] | join(" "))'
+          #
+          # The scheduled run is what surfaces the expiry.
           - name: "6.1"
-            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-09-30-15-36/ffmpeg-n6.1.2-8-gf00f71f590-linux64-gpl-6.1.tar.xz
+            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-08-31-13-00/ffmpeg-n6.1.3-linux64-gpl-6.1.tar.xz
           - name: "7.1"
-            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2024-09-30-15-36/ffmpeg-n7.1-linux64-gpl-7.1.tar.xz
+            url: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-01-31-12-57/ffmpeg-n7.1.3-35-g419cdf9dcc-linux64-gpl-7.1.tar.xz
           # 8.x, 9.x and master are rolling: the assets are rebuilt in place,
           # so the scheduled run picks up new point releases automatically.
           # This is the part that actually detects drift.


### PR DESCRIPTION
`ffmpeg 6.1` and `ffmpeg 7.1` fail at the download step with a 404, on every
PR — both are required checks, so nothing can merge. Nothing in this repo
changed; the release they pin was deleted upstream.

The pin was `autobuild-2024-09-30-15-36`, chosen on the belief that "release
assets themselves persist" (the comment says so). They do not. BtbN keeps
roughly the last two weeks of dailies plus one monthly snapshot going back
about two years, and deletes the rest outright — assets and all. That pin was
23 months old.

So an EOL branch is reachable only for as long as the newest surviving
snapshot that still carries it, and that is not the same snapshot for both:

| branch | newest snapshot still carrying it | asset |
|---|---|---|
| 6.1 | `autobuild-2025-08-31-13-00` | `ffmpeg-n6.1.3-linux64-gpl-6.1.tar.xz` |
| 7.1 | `autobuild-2026-01-31-12-57` | `ffmpeg-n7.1.3-35-g419cdf9dcc-linux64-gpl-7.1.tar.xz` |

Both verified 200. Pinning each separately rather than to one common release
buys 7.1 five extra months of runway.

The matrix entry names are unchanged, so the required-check names in branch
protection still match.

This will recur. The comment now says the pins expire, and carries the `gh api`
query that finds the next snapshot; the scheduled Monday run is what surfaces
it, and already opens an issue on failure.
